### PR TITLE
feat(gui): modularize asset workflows and PNG editing

### DIFF
--- a/src/core/assets.cc
+++ b/src/core/assets.cc
@@ -4,11 +4,8 @@
 #include "core/events/process/pointcloud-to-png-map.hh"
 
 #include <algorithm>
-#include <cctype>
 #include <filesystem>
 #include <format>
-#include <ranges>
-#include <spdlog/spdlog.h>
 #include <tuple>
 #include <unordered_map>
 #include <vector>
@@ -29,22 +26,6 @@ auto kind_label(AssetKind kind) noexcept -> std::string_view {
 
     return "Unknown";
 }
-
-auto normalized_extension(std::string const& location) -> std::string {
-    auto extension = std::filesystem::path(location).extension().string();
-    std::ranges::transform(extension, extension.begin(),
-        [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
-    return extension;
-}
-
-auto inferred_name(std::string const& location, std::string_view fallback) -> std::string {
-    if (location.empty()) {
-        return std::string { fallback };
-    }
-
-    return std::filesystem::path(location).filename().string();
-}
-
 }
 
 struct AssetsManager::Impl {
@@ -262,47 +243,6 @@ struct AssetsManager::Impl {
         return id;
     }
 
-    auto open_pointcloud_file(std::string const& location) noexcept -> void {
-        auto pointcloud = std::make_unique<PointsHandle>();
-        auto result     = pointcloud->load_from_filesystem(location);
-
-        if (!result.has_value()) {
-            spdlog::error("Failed to open pointcloud: {}", result.error());
-            return;
-        }
-
-        register_pointcloud(
-            std::move(pointcloud), inferred_name(location, "pointcloud.pcd"), location, true);
-    }
-
-    auto open_model_file(std::string const& location) noexcept -> void {
-        auto model  = std::make_unique<ModelHandle>();
-        auto result = model->load_from_filesystem(location);
-
-        if (!result.has_value()) {
-            spdlog::error("Failed to open model: {}", result.error());
-            return;
-        }
-
-        register_model(std::move(model), inferred_name(location, "model.obj"), location);
-    }
-
-    auto open_file(std::string const& location) noexcept -> void {
-        const auto extension = normalized_extension(location);
-
-        if (extension == ".pcd") {
-            open_pointcloud_file(location);
-            return;
-        }
-
-        if (extension == ".obj") {
-            open_model_file(location);
-            return;
-        }
-
-        spdlog::error("Unsupported asset file: {}", location);
-    }
-
     auto clean_assets() noexcept -> void {
         for (auto& [_, asset] : assets) {
             asset->release_unit(renderer);
@@ -416,7 +356,7 @@ struct AssetsManager::Impl {
         }
 
         auto context        = std::make_unique<event::ConvertModelToPointcloud::Context>();
-        context->poly_data  = asset->unit->poly_data();
+        context->model      = asset->unit->model_data();
         context->parameters = parameters;
 
         auto result = event::ConvertModelToPointcloud::runtime_exec(std::move(context));
@@ -696,6 +636,23 @@ auto AssetsManager::get_png_map_handle(std::string const& id) noexcept
     return std::nullopt;
 }
 
+auto AssetsManager::register_pointcloud_asset(std::unique_ptr<PointsHandle> pointcloud,
+    std::string const& name, std::string const& location, bool persisted) noexcept
+    -> std::string {
+    return pimpl->register_pointcloud(std::move(pointcloud), name, location, persisted);
+}
+
+auto AssetsManager::register_model_asset(std::unique_ptr<ModelHandle> model,
+    std::string const& name, std::string const& location) noexcept -> std::string {
+    return pimpl->register_model(std::move(model), name, location);
+}
+
+auto AssetsManager::register_png_map_asset(std::unique_ptr<PngMapHandle> png_map,
+    std::string const& name, std::string const& location, bool persisted) noexcept
+    -> std::string {
+    return pimpl->register_png_map(std::move(png_map), name, location, persisted);
+}
+
 auto AssetsManager::set_asset_visibility(std::string const& id, bool on) noexcept -> bool {
     return pimpl->set_asset_visibility(id, on);
 }
@@ -709,6 +666,12 @@ auto AssetsManager::convert_model_to_pointcloud(
 auto AssetsManager::generate_png_map_from_pointcloud(std::string const& id,
     PngMapParameters const& parameters) noexcept -> std::expected<std::string, std::string> {
     return pimpl->generate_png_map_from_pointcloud(id, parameters);
+}
+
+auto AssetsManager::upsert_generated_pointcloud(std::string const& source_id,
+    std::vector<std::tuple<double, double, double>> const& points) noexcept
+    -> std::expected<std::string, std::string> {
+    return pimpl->upsert_generated_pointcloud(source_id, points);
 }
 
 auto AssetsManager::create_png_map_asset_from_data(std::string const& source_id,
@@ -741,10 +704,6 @@ auto AssetsManager::remove_asset(std::string const& id) noexcept -> bool {
 }
 
 auto AssetsManager::update_renderer() const noexcept -> void { pimpl->renderer.render_window(); }
-
-auto AssetsManager::open_file(std::string const& location) noexcept -> void {
-    pimpl->open_file(location);
-}
 
 auto AssetsManager::clean_assets() noexcept -> void { pimpl->clean_assets(); }
 

--- a/src/core/assets.hh
+++ b/src/core/assets.hh
@@ -12,6 +12,8 @@
 #include <expected>
 #include <generator>
 #include <optional>
+#include <tuple>
+#include <vector>
 
 namespace pcs {
 
@@ -29,8 +31,6 @@ public:
 
     auto update_renderer() const noexcept -> void;
 
-    auto open_file(std::string const& location) noexcept -> void;
-
     auto clean_assets() noexcept -> void;
 
     auto get_asset_ids() const noexcept -> std::generator<std::string_view>;
@@ -44,10 +44,22 @@ public:
     auto get_model_handle(std::string const& id) noexcept -> std::optional<ModelHandle*>;
     auto get_png_map_handle(std::string const& id) noexcept -> std::optional<PngMapHandle*>;
 
+    auto register_pointcloud_asset(std::unique_ptr<PointsHandle>, std::string const& name,
+        std::string const& location, bool persisted = true) noexcept -> std::string;
+    auto register_model_asset(
+        std::unique_ptr<ModelHandle>, std::string const& name, std::string const& location) noexcept
+        -> std::string;
+    auto register_png_map_asset(std::unique_ptr<PngMapHandle>, std::string const& name,
+        std::string const& location, bool persisted = true) noexcept -> std::string;
+
     auto set_asset_visibility(std::string const& id, bool on) noexcept -> bool;
 
     auto convert_model_to_pointcloud(
         std::string const& id, ModelToPointcloudParameters const& = { }) noexcept
+        -> std::expected<std::string, std::string>;
+
+    auto upsert_generated_pointcloud(std::string const& source_id,
+        std::vector<std::tuple<double, double, double>> const& points) noexcept
         -> std::expected<std::string, std::string>;
 
     auto generate_png_map_from_pointcloud(std::string const& id, PngMapParameters const&) noexcept

--- a/src/core/events/process/model-to-pointcloud.cc
+++ b/src/core/events/process/model-to-pointcloud.cc
@@ -4,11 +4,74 @@
 #include <array>
 #include <cmath>
 #include <cstddef>
+#include <cstdint>
+#include <unordered_map>
+
+#include <vtk/vtkCellArray.h>
+#include <vtk/vtkCleanPolyData.h>
 #include <vtk/vtkPoints.h>
+#include <vtk/vtkPolyData.h>
 #include <vtk/vtkPolyDataPointSampler.h>
+#include <vtk/vtkRemoveDuplicatePolys.h>
+#include <vtk/vtkSelectEnclosedPoints.h>
 #include <vtk/vtkTriangleFilter.h>
 
 namespace {
+
+using Position3 = std::array<double, 3>;
+
+struct GridKey {
+    std::int64_t x { 0 };
+    std::int64_t y { 0 };
+    std::int64_t z { 0 };
+
+    auto operator==(GridKey const& other) const noexcept -> bool {
+        return x == other.x && y == other.y && z == other.z;
+    }
+};
+
+struct GridKeyHash {
+    auto operator()(GridKey const& key) const noexcept -> std::size_t {
+        auto h = std::size_t { };
+        h ^= static_cast<std::size_t>(key.x) * 73856093U;
+        h ^= static_cast<std::size_t>(key.y) * 19349663U;
+        h ^= static_cast<std::size_t>(key.z) * 83492791U;
+        return h;
+    }
+};
+
+auto build_poly_data(pcs::ModelData const& model) -> vtkSmartPointer<vtkPolyData> {
+    if (model.vertices.empty()) {
+        return nullptr;
+    }
+
+    auto points = vtkSmartPointer<vtkPoints>::New();
+    points->SetDataTypeToDouble();
+
+    for (auto const& vertex : model.vertices) {
+        points->InsertNextPoint(vertex[0], vertex[1], vertex[2]);
+    }
+
+    auto polys = vtkSmartPointer<vtkCellArray>::New();
+    for (auto const& face : model.faces) {
+        if (face[0] >= model.vertices.size() || face[1] >= model.vertices.size()
+            || face[2] >= model.vertices.size()) {
+            continue;
+        }
+
+        const auto triangle = std::array<vtkIdType, 3> {
+            static_cast<vtkIdType>(face[0]),
+            static_cast<vtkIdType>(face[1]),
+            static_cast<vtkIdType>(face[2]),
+        };
+        polys->InsertNextCell(static_cast<vtkIdType>(triangle.size()), triangle.data());
+    }
+
+    auto poly_data = vtkSmartPointer<vtkPolyData>::New();
+    poly_data->SetPoints(points);
+    poly_data->SetPolys(polys);
+    return poly_data;
+}
 
 auto calculate_default_sample_distance(vtkPolyData* poly_data) noexcept -> double {
     auto bounds = std::array<double, 6> { };
@@ -24,6 +87,145 @@ auto calculate_default_sample_distance(vtkPolyData* poly_data) noexcept -> doubl
     }
 
     return std::max(diagonal / 200.0, 1e-3);
+}
+
+auto calculate_bounds_diagonal(vtkPolyData* poly_data) noexcept -> double {
+    if (poly_data == nullptr) {
+        return 0.0;
+    }
+
+    auto bounds = std::array<double, 6> { };
+    poly_data->GetBounds(bounds.data());
+
+    const auto dx = bounds[1] - bounds[0];
+    const auto dy = bounds[3] - bounds[2];
+    const auto dz = bounds[5] - bounds[4];
+    return std::sqrt(dx * dx + dy * dy + dz * dz);
+}
+
+auto make_grid_key(Position3 const& point, double cell_size) noexcept -> GridKey {
+    const auto safe_cell = std::max(cell_size, 1e-6);
+
+    return {
+        static_cast<std::int64_t>(std::floor(point[0] / safe_cell)),
+        static_cast<std::int64_t>(std::floor(point[1] / safe_cell)),
+        static_cast<std::int64_t>(std::floor(point[2] / safe_cell)),
+    };
+}
+
+auto deduplicate_overlapped_samples(std::vector<Position3>& samples, double cell_size) noexcept
+    -> void {
+    if (samples.empty()) {
+        return;
+    }
+
+    auto reduced = std::vector<Position3> { };
+    reduced.reserve(samples.size());
+
+    auto occupied = std::unordered_map<GridKey, std::size_t, GridKeyHash> { };
+    occupied.reserve(samples.size());
+
+    for (auto const& point : samples) {
+        auto key = make_grid_key(point, cell_size);
+        if (!occupied.contains(key)) {
+            occupied.emplace(key, reduced.size());
+            reduced.push_back(point);
+        }
+    }
+
+    samples = std::move(reduced);
+}
+
+auto remove_internal_surface_samples(
+    std::vector<Position3>& samples, vtkPolyData* surface, double probe_offset) noexcept -> void {
+    if (samples.empty() || surface == nullptr) {
+        return;
+    }
+
+    if (vtkSelectEnclosedPoints::IsSurfaceClosed(surface) <= 0) {
+        return;
+    }
+
+    auto enclosed = vtkSmartPointer<vtkSelectEnclosedPoints>::New();
+    enclosed->SetTolerance(1e-6);
+    enclosed->Initialize(surface);
+
+    static constexpr auto directions = std::array<Position3, 6> {
+        Position3 { 1.0, 0.0, 0.0 },
+        Position3 { -1.0, 0.0, 0.0 },
+        Position3 { 0.0, 1.0, 0.0 },
+        Position3 { 0.0, -1.0, 0.0 },
+        Position3 { 0.0, 0.0, 1.0 },
+        Position3 { 0.0, 0.0, -1.0 },
+    };
+
+    auto filtered = std::vector<Position3> { };
+    filtered.reserve(samples.size());
+
+    for (auto const& point : samples) {
+        auto has_outside_direction = false;
+
+        for (auto const& direction : directions) {
+            auto probe = Position3 {
+                point[0] + direction[0] * probe_offset,
+                point[1] + direction[1] * probe_offset,
+                point[2] + direction[2] * probe_offset,
+            };
+
+            if (enclosed->IsInsideSurface(probe[0], probe[1], probe[2]) == 0) {
+                has_outside_direction = true;
+                break;
+            }
+        }
+
+        if (has_outside_direction) {
+            filtered.push_back(point);
+        }
+    }
+
+    enclosed->Complete();
+
+    if (!filtered.empty()) {
+        samples = std::move(filtered);
+    }
+}
+
+auto regularize_density(std::vector<Position3>& samples, double cell_size) noexcept -> void {
+    if (samples.empty()) {
+        return;
+    }
+
+    struct Accumulator {
+        Position3 sum { 0.0, 0.0, 0.0 };
+        std::size_t count { 0 };
+    };
+
+    auto buckets = std::unordered_map<GridKey, Accumulator, GridKeyHash> { };
+    buckets.reserve(samples.size());
+
+    for (auto const& point : samples) {
+        auto key  = make_grid_key(point, cell_size);
+        auto& acc = buckets[key];
+        acc.sum[0] += point[0];
+        acc.sum[1] += point[1];
+        acc.sum[2] += point[2];
+        acc.count += 1;
+    }
+
+    auto reduced = std::vector<Position3> { };
+    reduced.reserve(buckets.size());
+
+    for (auto const& [_, acc] : buckets) {
+        if (acc.count == 0) {
+            continue;
+        }
+
+        const auto inv_count = 1.0 / static_cast<double>(acc.count);
+        reduced.push_back(
+            { acc.sum[0] * inv_count, acc.sum[1] * inv_count, acc.sum[2] * inv_count });
+    }
+
+    samples = std::move(reduced);
 }
 
 auto apply_max_points_limit(std::vector<pcs::event::ConvertModelToPointcloud::Position>& positions,
@@ -56,16 +258,16 @@ auto apply_max_points_limit(std::vector<pcs::event::ConvertModelToPointcloud::Po
 namespace pcs::event {
 
 auto ConvertModelToPointcloud::runtime_exec(std::unique_ptr<Context> context) noexcept -> Result {
-    if (context == nullptr || context->poly_data == nullptr) {
+    if (context == nullptr || context->model.vertices.empty()) {
+        return std::unexpected { "Model data is not loaded" };
+    }
+
+    auto poly_data = build_poly_data(context->model);
+    if (poly_data == nullptr || poly_data->GetNumberOfPoints() == 0) {
         return std::unexpected { "Model polydata is not loaded" };
     }
 
     const auto& parameters = context->parameters;
-    if (!parameters.include_edge_points && !parameters.include_interior_points
-        && !parameters.include_vertex_points) {
-        return std::unexpected { "At least one sampling source must be enabled" };
-    }
-
     if (parameters.density <= 0.0) {
         return std::unexpected { "Density must be greater than 0" };
     }
@@ -74,42 +276,39 @@ auto ConvertModelToPointcloud::runtime_exec(std::unique_ptr<Context> context) no
         return std::unexpected { "Unit scale must be greater than 0" };
     }
 
-    const auto base_distance = parameters.sample_distance > 0.0
+    const auto base_distance      = parameters.sample_distance > 0.0
         ? parameters.sample_distance
-        : calculate_default_sample_distance(context->poly_data);
-
-    const auto sample_distance = std::max(base_distance / std::sqrt(parameters.density), 1e-5);
+        : calculate_default_sample_distance(poly_data);
+    const auto effective_distance = std::max(base_distance / std::sqrt(parameters.density), 1e-5);
 
     auto triangle = vtkSmartPointer<vtkTriangleFilter>::New();
     triangle->PassVertsOff();
     triangle->PassLinesOff();
-    triangle->SetInputData(context->poly_data);
-    triangle->Update();
+    triangle->SetInputData(poly_data);
+
+    auto clean = vtkSmartPointer<vtkCleanPolyData>::New();
+    clean->SetInputConnection(triangle->GetOutputPort());
+    clean->ToleranceIsAbsoluteOn();
+    clean->SetAbsoluteTolerance(0.0);
+    clean->PointMergingOn();
+
+    auto remove_duplicate_polys = vtkSmartPointer<vtkRemoveDuplicatePolys>::New();
+    remove_duplicate_polys->SetInputConnection(clean->GetOutputPort());
 
     auto sampler = vtkSmartPointer<vtkPolyDataPointSampler>::New();
-    sampler->SetInputConnection(triangle->GetOutputPort());
+    sampler->SetInputConnection(remove_duplicate_polys->GetOutputPort());
     sampler->SetPointGenerationModeToRegular();
-    if (parameters.include_vertex_points) {
-        sampler->GenerateVertexPointsOn();
-    } else {
-        sampler->GenerateVertexPointsOff();
-    }
-
-    if (parameters.include_edge_points) {
-        sampler->GenerateEdgePointsOn();
-    } else {
-        sampler->GenerateEdgePointsOff();
-    }
-
-    if (parameters.include_interior_points) {
-        sampler->GenerateInteriorPointsOn();
-    } else {
-        sampler->GenerateInteriorPointsOff();
-    }
-
+    sampler->GenerateVertexPointsOff();
+    sampler->GenerateEdgePointsOn();
+    sampler->GenerateInteriorPointsOn();
     sampler->GenerateVerticesOff();
-    sampler->SetDistance(sample_distance);
+    sampler->SetDistance(effective_distance);
     sampler->Update();
+
+    auto* surface = remove_duplicate_polys->GetOutput();
+    if (surface == nullptr) {
+        return std::unexpected { "Failed to prepare model surface" };
+    }
 
     auto sampled = sampler->GetOutput();
     auto* points = sampled->GetPoints();
@@ -118,12 +317,28 @@ auto ConvertModelToPointcloud::runtime_exec(std::unique_ptr<Context> context) no
         return std::unexpected { "Failed to sample pointcloud from model" };
     }
 
-    auto positions = std::vector<std::tuple<double, double, double>> { };
-    positions.reserve(points->GetNumberOfPoints());
+    auto raw_samples = std::vector<Position3> { };
+    raw_samples.reserve(points->GetNumberOfPoints());
 
     for (vtkIdType i = 0; i < points->GetNumberOfPoints(); ++i) {
         auto point = std::array<double, 3> { };
         points->GetPoint(i, point.data());
+        raw_samples.push_back(point);
+    }
+
+    deduplicate_overlapped_samples(raw_samples, effective_distance * 0.45);
+
+    const auto surface_diagonal = calculate_bounds_diagonal(surface);
+    const auto probe_offset =
+        std::max(effective_distance * 0.4, std::max(surface_diagonal * 1e-5, 1e-6));
+    remove_internal_surface_samples(raw_samples, surface, probe_offset);
+
+    regularize_density(raw_samples, effective_distance);
+
+    auto positions = std::vector<std::tuple<double, double, double>> { };
+    positions.reserve(raw_samples.size());
+
+    for (auto const& point : raw_samples) {
         positions.emplace_back(point[0] * parameters.unit_scale, point[1] * parameters.unit_scale,
             point[2] * parameters.unit_scale);
     }

--- a/src/core/events/process/model-to-pointcloud.hh
+++ b/src/core/events/process/model-to-pointcloud.hh
@@ -1,14 +1,12 @@
 #pragma once
 
 #include "core/events/common.hh"
+#include "core/map/model-data.hh"
 #include "core/map/model-pointcloud-data.hh"
 
 #include <expected>
 #include <tuple>
 #include <vector>
-
-#include <vtk/vtkPolyData.h>
-#include <vtk/vtkSmartPointer.h>
 
 namespace pcs::event {
 
@@ -22,7 +20,7 @@ struct ConvertModelToPointcloud {
             .consuming = true,
         };
 
-        vtkSmartPointer<vtkPolyData> poly_data;
+        ModelData model;
         ModelToPointcloudParameters parameters;
     };
 

--- a/src/core/events/process/png-map-edit.cc
+++ b/src/core/events/process/png-map-edit.cc
@@ -1,0 +1,28 @@
+#include "png-map-edit.hh"
+
+namespace pcs::event {
+
+auto ApplyPngMapEdit::runtime_exec(std::unique_ptr<Context> context) noexcept -> Result {
+    if (context == nullptr) {
+        return std::unexpected { "PNG 编辑上下文为空" };
+    }
+
+    if (context->width == 0 || context->height == 0) {
+        return std::unexpected { "PNG 地图尺寸无效" };
+    }
+
+    if (context->pixels.size() != context->width * context->height) {
+        return std::unexpected { "PNG 像素缓冲尺寸不匹配" };
+    }
+
+    auto pixels = std::move(context->pixels);
+    const auto value =
+        context->operation == PngMapEditOperation::Erase ? std::uint8_t { 255 } : std::uint8_t { 0 };
+
+    draw_line_with_thickness(pixels, context->width, context->height, context->from, context->to,
+        context->thickness, value);
+
+    return pixels;
+}
+
+}

--- a/src/core/events/process/png-map-edit.hh
+++ b/src/core/events/process/png-map-edit.hh
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "core/events/common.hh"
+#include "core/map/png-edit-ops.hh"
+
+#include <cstddef>
+#include <cstdint>
+#include <expected>
+#include <vector>
+
+namespace pcs::event {
+
+enum class PngMapEditOperation {
+    Draw,
+    Erase,
+};
+
+struct ApplyPngMapEdit {
+    using Result = std::expected<std::vector<std::uint8_t>, std::string>;
+
+    struct Context {
+        static constexpr EventMeta meta {
+            .name      = "Apply PNG Map Edit",
+            .consuming = true,
+        };
+
+        std::vector<std::uint8_t> pixels;
+        std::size_t width  = 0;
+        std::size_t height = 0;
+        PixelPoint from;
+        PixelPoint to;
+        std::size_t thickness = 1;
+        PngMapEditOperation operation { PngMapEditOperation::Draw };
+    };
+
+    static auto runtime_exec(std::unique_ptr<Context>) noexcept -> Result;
+};
+
+}

--- a/src/core/events/render/png-map.cc
+++ b/src/core/events/render/png-map.cc
@@ -1,0 +1,20 @@
+#include "png-map.hh"
+
+#include <format>
+
+using namespace pcs::event;
+
+auto MakePngMapUnit::runtime_exec(std::unique_ptr<Context> context) noexcept -> Result {
+    const auto& path = context->path;
+
+    auto handle = std::make_unique<pcs::PngMapHandle>();
+    auto result = handle->load_from_filesystem(path);
+
+    if (!result.has_value()) {
+        return std::unexpected {
+            std::format("PNG map unit created failed: {}", result.error()),
+        };
+    }
+
+    return handle;
+}

--- a/src/core/events/render/png-map.hh
+++ b/src/core/events/render/png-map.hh
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "core/events/common.hh"
+#include "core/handle/png-map.hh"
+
+#include <expected>
+
+namespace pcs::event {
+
+struct MakePngMapUnit {
+    using Result = std::expected<std::unique_ptr<PngMapHandle>, std::string>;
+
+    struct Context {
+        static constexpr EventMeta meta {
+            .name      = "Make PNG Map Unit",
+            .consuming = true,
+        };
+        std::string path;
+        std::string name;
+    };
+
+    static auto runtime_exec(std::unique_ptr<Context>) noexcept -> Result;
+};
+
+}

--- a/src/core/handle/model.cc
+++ b/src/core/handle/model.cc
@@ -1,5 +1,4 @@
 #include "core/handle/model.impl.hh"
-#include "core/renderer.vtk.hh"
 
 using namespace pcs;
 
@@ -41,12 +40,12 @@ auto ModelHandle::load_from_filesystem(std::string const& path) noexcept
     return pimpl->load_from_filesystem(path);
 }
 
-auto ModelHandle::poly_data() const noexcept -> vtkSmartPointer<vtkPolyData> { return pimpl->data; }
+auto ModelHandle::model_data() const noexcept -> ModelData const& { return pimpl->data; }
 
 auto ModelHandle::attach_renderer(Renderer& r) noexcept -> void {
-    r.vtk_context().attach_unit(pimpl->unit->actor());
+    r.attach_model_unit(*pimpl->unit);
 }
 
 auto ModelHandle::detach_renderer(Renderer& r) noexcept -> void {
-    r.vtk_context().detach_unit(pimpl->unit->actor());
+    r.detach_model_unit(*pimpl->unit);
 }

--- a/src/core/handle/model.hh
+++ b/src/core/handle/model.hh
@@ -1,13 +1,11 @@
 #pragma once
 
+#include "core/map/model-data.hh"
 #include "core/renderer.hh"
 #include "utility/pimpl.hh"
 
 #include <expected>
 #include <tuple>
-
-#include <vtk/vtkPolyData.h>
-#include <vtk/vtkSmartPointer.h>
 
 namespace pcs {
 
@@ -31,7 +29,7 @@ public:
     auto load_from_filesystem(std::string const& path) noexcept
         -> std::expected<void, std::string_view>;
 
-    auto poly_data() const noexcept -> vtkSmartPointer<vtkPolyData>;
+    auto model_data() const noexcept -> ModelData const&;
 
     auto attach_renderer(Renderer&) noexcept -> void;
 

--- a/src/core/handle/model.impl.hh
+++ b/src/core/handle/model.impl.hh
@@ -3,12 +3,10 @@
 #include "core/handle/model.hh"
 #include "core/units/model.hh"
 
-#include <vtk/vtkCellArray.h>
-#include <vtk/vtkPoints.h>
-#include <vtk/vtkPolyData.h>
-
+#include <array>
 #include <charconv>
 #include <fstream>
+#include <optional>
 #include <sstream>
 #include <string>
 #include <string_view>
@@ -19,7 +17,7 @@ namespace {
 constexpr auto kObjToSceneScale = 0.001;
 
 auto parse_index_token(std::string_view token, std::size_t vertex_count) noexcept
-    -> std::optional<vtkIdType> {
+    -> std::optional<std::size_t> {
     const auto slash = token.find('/');
     token            = token.substr(0, slash);
 
@@ -34,28 +32,27 @@ auto parse_index_token(std::string_view token, std::size_t vertex_count) noexcep
     }
 
     if (parsed > 0) {
-        return static_cast<vtkIdType>(parsed - 1);
+        return static_cast<std::size_t>(parsed - 1);
     }
 
     if (parsed < 0) {
         const auto index = static_cast<long long>(vertex_count) + parsed;
         if (index >= 0) {
-            return static_cast<vtkIdType>(index);
+            return static_cast<std::size_t>(index);
         }
     }
 
     return std::nullopt;
 }
 
-auto load_obj_poly_data(std::string const& path) noexcept
-    -> std::expected<vtkSmartPointer<vtkPolyData>, std::string_view> {
+auto load_obj_data(std::string const& path) noexcept
+    -> std::expected<pcs::ModelData, std::string_view> {
     auto input = std::ifstream { path };
     if (!input.is_open()) {
         return std::unexpected { "Failed to open model from filesystem" };
     }
 
-    auto points = vtkSmartPointer<vtkPoints>::New();
-    auto polys  = vtkSmartPointer<vtkCellArray>::New();
+    auto model = pcs::ModelData { };
 
     for (auto line = std::string { }; std::getline(input, line);) {
         auto stream = std::istringstream { line };
@@ -67,8 +64,8 @@ auto load_obj_poly_data(std::string const& path) noexcept
             auto y = double { };
             auto z = double { };
             if (stream >> x >> y >> z) {
-                points->InsertNextPoint(
-                    x * kObjToSceneScale, y * kObjToSceneScale, z * kObjToSceneScale);
+                model.vertices.push_back(
+                    { x * kObjToSceneScale, y * kObjToSceneScale, z * kObjToSceneScale });
             }
             continue;
         }
@@ -77,10 +74,9 @@ auto load_obj_poly_data(std::string const& path) noexcept
             continue;
         }
 
-        auto vertices = std::vector<vtkIdType> { };
+        auto vertices = std::vector<std::size_t> { };
         for (auto token = std::string { }; stream >> token;) {
-            auto index =
-                parse_index_token(token, static_cast<std::size_t>(points->GetNumberOfPoints()));
+            auto index = parse_index_token(token, model.vertices.size());
             if (index.has_value()) {
                 vertices.push_back(*index);
             }
@@ -91,20 +87,15 @@ auto load_obj_poly_data(std::string const& path) noexcept
         }
 
         for (std::size_t i = 1; i + 1 < vertices.size(); ++i) {
-            const auto triangle =
-                std::array<vtkIdType, 3> { vertices[0], vertices[i], vertices[i + 1] };
-            polys->InsertNextCell(static_cast<vtkIdType>(triangle.size()), triangle.data());
+            model.faces.push_back({ vertices[0], vertices[i], vertices[i + 1] });
         }
     }
 
-    if (points->GetNumberOfPoints() == 0) {
+    if (model.vertices.empty()) {
         return std::unexpected { "Failed to read model from filesystem" };
     }
 
-    auto data = vtkSmartPointer<vtkPolyData>::New();
-    data->SetPoints(points);
-    data->SetPolys(polys);
-    return data;
+    return model;
 }
 
 }
@@ -113,17 +104,16 @@ using namespace pcs;
 
 struct ModelHandle::Impl final {
     std::unique_ptr<ModelUnit> unit;
-    vtkSmartPointer<vtkPolyData> data;
+    ModelData data;
 
     auto load_from_filesystem(std::string const& path) noexcept
         -> std::expected<void, std::string_view> {
-        auto result = load_obj_poly_data(path);
+        auto result = load_obj_data(path);
         if (!result.has_value()) {
             return std::unexpected { result.error() };
         }
 
         data = std::move(result).value();
-
         unit = std::make_unique<ModelUnit>(data);
         return { };
     }

--- a/src/core/handle/png-map.cc
+++ b/src/core/handle/png-map.cc
@@ -1,5 +1,4 @@
 #include "core/handle/png-map.impl.hh"
-#include "core/renderer.vtk.hh"
 
 using namespace pcs;
 
@@ -9,6 +8,11 @@ PngMapHandle::PngMapHandle() noexcept
 PngMapHandle::~PngMapHandle() noexcept = default;
 
 auto PngMapHandle::set_visibility(bool on) noexcept -> void { pimpl->unit->set_visibility(on); }
+
+auto PngMapHandle::load_from_filesystem(std::string const& path) noexcept
+    -> std::expected<void, std::string_view> {
+    return pimpl->load_from_filesystem(path);
+}
 
 auto PngMapHandle::load_from_data(PngMapData const& map) noexcept
     -> std::expected<void, std::string_view> {
@@ -24,13 +28,32 @@ auto PngMapHandle::get_width() const noexcept -> std::size_t { return pimpl->dat
 auto PngMapHandle::get_height() const noexcept -> std::size_t { return pimpl->data.height; }
 auto PngMapHandle::get_resolution() const noexcept -> double { return pimpl->data.resolution; }
 auto PngMapHandle::get_plane_z() const noexcept -> double { return pimpl->data.plane_z; }
+auto PngMapHandle::get_origin_x() const noexcept -> double { return pimpl->data.origin_x; }
+auto PngMapHandle::get_origin_y() const noexcept -> double { return pimpl->data.origin_y; }
+
+auto PngMapHandle::copy_pixels() const noexcept -> std::vector<std::uint8_t> {
+    return pimpl->copy_pixels();
+}
+
+auto PngMapHandle::overwrite_pixels(std::vector<std::uint8_t> const& pixels) noexcept -> bool {
+    return pimpl->overwrite_pixels(pixels);
+}
+
+auto PngMapHandle::preview_pixels(std::vector<std::uint8_t> const& pixels) noexcept -> bool {
+    return pimpl->preview_pixels(pixels);
+}
+
+auto PngMapHandle::clear_preview() noexcept -> bool { return pimpl->clear_preview(); }
+
+auto PngMapHandle::pick_plane_position(Renderer& renderer, int display_x,
+    int display_y) const noexcept -> std::optional<PngMapHandle::Position> {
+    return renderer.pick_png_map_unit(*pimpl->unit, display_x, display_y);
+}
 
 auto PngMapHandle::attach_renderer(Renderer& renderer) noexcept -> void {
-    renderer.vtk_context().attach_unit(pimpl->unit->actor());
-    renderer.vtk_context().attach_unit(pimpl->unit->area_actor());
+    renderer.attach_png_map_unit(*pimpl->unit);
 }
 
 auto PngMapHandle::detach_renderer(Renderer& renderer) noexcept -> void {
-    renderer.vtk_context().detach_unit(pimpl->unit->actor());
-    renderer.vtk_context().detach_unit(pimpl->unit->area_actor());
+    renderer.detach_png_map_unit(*pimpl->unit);
 }

--- a/src/core/handle/png-map.hh
+++ b/src/core/handle/png-map.hh
@@ -5,6 +5,8 @@
 #include "utility/pimpl.hh"
 
 #include <expected>
+#include <optional>
+#include <tuple>
 
 namespace pcs {
 
@@ -12,8 +14,12 @@ struct PngMapHandle {
     PCS_PIMPL_DEFINITION(PngMapHandle)
 
 public:
+    using Position = std::tuple<double, double, double>;
+
     auto set_visibility(bool) noexcept -> void;
 
+    auto load_from_filesystem(std::string const& path) noexcept
+        -> std::expected<void, std::string_view>;
     auto load_from_data(PngMapData const&) noexcept -> std::expected<void, std::string_view>;
     auto save_into_filesystem(std::string const& path) const noexcept
         -> std::expected<void, std::string_view>;
@@ -22,6 +28,16 @@ public:
     auto get_height() const noexcept -> std::size_t;
     auto get_resolution() const noexcept -> double;
     auto get_plane_z() const noexcept -> double;
+    auto get_origin_x() const noexcept -> double;
+    auto get_origin_y() const noexcept -> double;
+
+    auto copy_pixels() const noexcept -> std::vector<std::uint8_t>;
+    auto overwrite_pixels(std::vector<std::uint8_t> const&) noexcept -> bool;
+    auto preview_pixels(std::vector<std::uint8_t> const&) noexcept -> bool;
+    auto clear_preview() noexcept -> bool;
+
+    auto pick_plane_position(Renderer&, int display_x, int display_y) const noexcept
+        -> std::optional<Position>;
 
     auto attach_renderer(Renderer&) noexcept -> void;
     auto detach_renderer(Renderer&) noexcept -> void;

--- a/src/core/handle/png-map.impl.hh
+++ b/src/core/handle/png-map.impl.hh
@@ -13,6 +13,37 @@ struct PngMapHandle::Impl final {
     PngMapData data;
     std::unique_ptr<PngMapUnit> unit;
 
+    auto load_from_filesystem(std::string const& path) noexcept
+        -> std::expected<void, std::string_view> {
+        auto image = QImage(QString::fromStdString(path));
+        if (image.isNull()) {
+            return std::unexpected { "Failed to load png map from filesystem" };
+        }
+
+        auto grayscale = image.convertToFormat(QImage::Format_Grayscale8);
+        if (grayscale.isNull()) {
+            return std::unexpected { "Failed to convert png map into grayscale" };
+        }
+
+        auto map       = PngMapData { };
+        map.width      = static_cast<std::size_t>(grayscale.width());
+        map.height     = static_cast<std::size_t>(grayscale.height());
+        map.resolution = 0.1;
+        map.plane_z    = 0.0;
+        map.origin_x   = 0.0;
+        map.origin_y   = 0.0;
+        map.z_area_start = 0.0;
+        map.z_area_end   = 1.0;
+        map.pixels.resize(map.width * map.height);
+
+        for (std::size_t y = 0; y < map.height; ++y) {
+            auto const* row_ptr = grayscale.constScanLine(static_cast<int>(y));
+            std::memcpy(map.pixels.data() + y * map.width, row_ptr, map.width * sizeof(std::uint8_t));
+        }
+
+        return load_from_data(map);
+    }
+
     auto load_from_data(PngMapData const& map) noexcept -> std::expected<void, std::string_view> {
         if (map.width == 0 || map.height == 0 || map.pixels.size() != map.width * map.height) {
             return std::unexpected { "Invalid png map data" };
@@ -47,5 +78,40 @@ struct PngMapHandle::Impl final {
         }
 
         return { };
+    }
+
+    auto copy_pixels() const noexcept -> std::vector<std::uint8_t> { return data.pixels; }
+
+    auto overwrite_pixels(std::vector<std::uint8_t> const& pixels) noexcept -> bool {
+        if (unit == nullptr || data.width == 0 || data.height == 0) {
+            return false;
+        }
+
+        if (pixels.size() != data.width * data.height) {
+            return false;
+        }
+
+        data.pixels = pixels;
+        return unit->update_pixels(data.pixels);
+    }
+
+    auto preview_pixels(std::vector<std::uint8_t> const& pixels) noexcept -> bool {
+        if (unit == nullptr || data.width == 0 || data.height == 0) {
+            return false;
+        }
+
+        if (pixels.size() != data.width * data.height) {
+            return false;
+        }
+
+        return unit->update_pixels(pixels);
+    }
+
+    auto clear_preview() noexcept -> bool {
+        if (unit == nullptr || data.width == 0 || data.height == 0) {
+            return false;
+        }
+
+        return unit->update_pixels(data.pixels);
     }
 };

--- a/src/core/handle/points.cc
+++ b/src/core/handle/points.cc
@@ -1,5 +1,4 @@
 #include "core/handle/points.impl.hh"
-#include "core/renderer.vtk.hh"
 
 using namespace pcs;
 
@@ -35,15 +34,20 @@ auto PointsHandle::get_positions() const noexcept -> std::vector<Position> {
     return pimpl->get_positions();
 }
 
+auto PointsHandle::pick_position(Renderer& renderer, int display_x, int display_y) const noexcept
+    -> std::optional<PointsHandle::Position> {
+    return renderer.pick_points_unit(*pimpl->unit, display_x, display_y);
+}
+
 auto PointsHandle::set_visibility(bool on) noexcept -> void {
     pimpl->unit->set_visibility(on); //
 }
 
 auto PointsHandle::attach_renderer(Renderer& r) noexcept -> void {
-    r.vtk_context().attach_unit(pimpl->unit->actor());
+    r.attach_points_unit(*pimpl->unit);
 }
 auto PointsHandle::detach_renderer(Renderer& r) noexcept -> void {
-    r.vtk_context().detach_unit(pimpl->unit->actor());
+    r.detach_points_unit(*pimpl->unit);
 }
 
 auto PointsHandle::load_from_filesystem(std::string const& path) noexcept

--- a/src/core/handle/points.hh
+++ b/src/core/handle/points.hh
@@ -4,6 +4,7 @@
 #include "utility/pimpl.hh"
 
 #include <expected>
+#include <optional>
 #include <tuple>
 #include <vector>
 
@@ -24,6 +25,9 @@ public:
     auto get_points_size() const noexcept -> std::size_t;
 
     auto get_positions() const noexcept -> std::vector<Position>;
+
+    auto pick_position(Renderer&, int display_x, int display_y) const noexcept
+        -> std::optional<Position>;
 
     auto set_visibility(bool) noexcept -> void;
 

--- a/src/core/map/model-data.hh
+++ b/src/core/map/model-data.hh
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <vector>
+
+namespace pcs {
+
+struct ModelData {
+    std::vector<std::array<double, 3>> vertices;
+    std::vector<std::array<std::size_t, 3>> faces;
+};
+
+}

--- a/src/core/map/model-pointcloud-data.hh
+++ b/src/core/map/model-pointcloud-data.hh
@@ -5,13 +5,10 @@
 namespace pcs {
 
 struct ModelToPointcloudParameters {
-    double density               = 1.0;
-    double sample_distance       = 0.0;
-    double unit_scale            = 1.0;
-    bool include_edge_points     = true;
-    bool include_interior_points = true;
-    bool include_vertex_points   = false;
-    std::size_t max_points       = 0;
+    double density         = 10.0;
+    double sample_distance = 0.0;
+    double unit_scale      = 1.0;
+    std::size_t max_points = 0;
 };
 
 }

--- a/src/core/map/png-edit-ops.cc
+++ b/src/core/map/png-edit-ops.cc
@@ -1,0 +1,109 @@
+#include "core/map/png-edit-ops.hh"
+
+#include <algorithm>
+#include <cmath>
+
+namespace pcs {
+
+namespace {
+
+    auto put_pixel(std::vector<std::uint8_t>& pixels, std::size_t width, std::size_t height, int x,
+        int y, std::uint8_t value) noexcept -> void {
+        if (x < 0 || y < 0) {
+            return;
+        }
+
+        if (static_cast<std::size_t>(x) >= width || static_cast<std::size_t>(y) >= height) {
+            return;
+        }
+
+        pixels[static_cast<std::size_t>(y) * width + static_cast<std::size_t>(x)] = value;
+    }
+
+    auto draw_disk(std::vector<std::uint8_t>& pixels, std::size_t width, std::size_t height,
+        PixelPoint center, int radius, std::uint8_t value) noexcept -> void {
+        if (radius <= 0) {
+            put_pixel(pixels, width, height, center.x, center.y, value);
+            return;
+        }
+
+        const auto radius_sq = radius * radius;
+        for (auto dy = -radius; dy <= radius; ++dy) {
+            for (auto dx = -radius; dx <= radius; ++dx) {
+                if (dx * dx + dy * dy > radius_sq) {
+                    continue;
+                }
+
+                put_pixel(pixels, width, height, center.x + dx, center.y + dy, value);
+            }
+        }
+    }
+
+}
+
+auto draw_line_with_thickness(std::vector<std::uint8_t>& pixels, std::size_t width,
+    std::size_t height, PixelPoint from, PixelPoint to, std::size_t thickness,
+    std::uint8_t value) noexcept -> void {
+    if (pixels.empty() || width == 0 || height == 0) {
+        return;
+    }
+
+    const auto line_thickness = std::max<std::size_t>(thickness, 1);
+    const auto radius         = static_cast<int>((line_thickness - 1U) / 2U);
+
+    auto x0 = from.x;
+    auto y0 = from.y;
+    auto x1 = to.x;
+    auto y1 = to.y;
+
+    auto dx  = std::abs(x1 - x0);
+    auto sx  = x0 < x1 ? 1 : -1;
+    auto dy  = -std::abs(y1 - y0);
+    auto sy  = y0 < y1 ? 1 : -1;
+    auto err = dx + dy;
+
+    while (true) {
+        draw_disk(pixels, width, height, PixelPoint { x0, y0 }, radius, value);
+
+        if (x0 == x1 && y0 == y1) {
+            break;
+        }
+
+        const auto e2 = err * 2;
+        if (e2 >= dy) {
+            err += dy;
+            x0 += sx;
+        }
+        if (e2 <= dx) {
+            err += dx;
+            y0 += sy;
+        }
+    }
+}
+
+auto nearest_point_index(std::vector<PixelPoint> const& points, PixelPoint target,
+    double max_distance) noexcept -> std::optional<std::size_t> {
+    if (points.empty() || max_distance < 0.0) {
+        return std::nullopt;
+    }
+
+    auto nearest      = std::optional<std::size_t> { };
+    auto best_sq_dist = max_distance * max_distance;
+
+    for (std::size_t i = 0; i < points.size(); ++i) {
+        const auto dx = static_cast<double>(points[i].x - target.x);
+        const auto dy = static_cast<double>(points[i].y - target.y);
+        const auto sq = dx * dx + dy * dy;
+
+        if (sq > best_sq_dist) {
+            continue;
+        }
+
+        best_sq_dist = sq;
+        nearest      = i;
+    }
+
+    return nearest;
+}
+
+}

--- a/src/core/map/png-edit-ops.hh
+++ b/src/core/map/png-edit-ops.hh
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+namespace pcs {
+
+struct PixelPoint {
+    int x = 0;
+    int y = 0;
+};
+
+auto draw_line_with_thickness(std::vector<std::uint8_t>& pixels, std::size_t width,
+    std::size_t height, PixelPoint from, PixelPoint to, std::size_t thickness,
+    std::uint8_t value) noexcept -> void;
+
+auto nearest_point_index(std::vector<PixelPoint> const& points, PixelPoint target,
+    double max_distance) noexcept -> std::optional<std::size_t>;
+
+}

--- a/src/core/map/png-map-data.hh
+++ b/src/core/map/png-map-data.hh
@@ -12,7 +12,7 @@ struct PngMapParameters {
     double height_limit      = 0.1;
     double influence_radius  = 0.08;
     double z_area_start      = 0.0;
-    double z_area_end        = 0.2;
+    double z_area_end        = 1.0;
 };
 
 struct PngMapData {
@@ -28,7 +28,7 @@ struct PngMapData {
     double plane_z = -0.02;
 
     double z_area_start = 0.0;
-    double z_area_end   = 0.2;
+    double z_area_end   = 1.0;
 };
 
 }

--- a/src/core/renderer.cc
+++ b/src/core/renderer.cc
@@ -19,6 +19,40 @@ auto Renderer::set_background(double r, double g, double b) noexcept -> void {
     pimpl->set_background(r, g, b);
 }
 
+auto Renderer::attach_points_unit(PointsUnit const& unit) noexcept -> void {
+    pimpl->attach_points_unit(unit);
+}
+
+auto Renderer::detach_points_unit(PointsUnit const& unit) noexcept -> void {
+    pimpl->detach_points_unit(unit);
+}
+
+auto Renderer::attach_model_unit(ModelUnit const& unit) noexcept -> void {
+    pimpl->attach_model_unit(unit);
+}
+
+auto Renderer::detach_model_unit(ModelUnit const& unit) noexcept -> void {
+    pimpl->detach_model_unit(unit);
+}
+
+auto Renderer::attach_png_map_unit(PngMapUnit const& unit) noexcept -> void {
+    pimpl->attach_png_map_unit(unit);
+}
+
+auto Renderer::detach_png_map_unit(PngMapUnit const& unit) noexcept -> void {
+    pimpl->detach_png_map_unit(unit);
+}
+
+auto Renderer::pick_points_unit(PointsUnit const& unit, int display_x, int display_y) noexcept
+    -> std::optional<Position> {
+    return pimpl->pick_points_unit(unit, display_x, display_y);
+}
+
+auto Renderer::pick_png_map_unit(PngMapUnit const& unit, int display_x, int display_y) noexcept
+    -> std::optional<Position> {
+    return pimpl->pick_png_map_unit(unit, display_x, display_y);
+}
+
 Renderer::Renderer() noexcept
     : pimpl { std::make_unique<Impl>() } { }
 

--- a/src/core/renderer.hh
+++ b/src/core/renderer.hh
@@ -2,13 +2,23 @@
 #include "utility/pimpl.hh"
 #include "utility/qt_binding.hh"
 
+#include <optional>
+#include <tuple>
+
 namespace pcs {
+
+class PointsUnit;
+class ModelUnit;
+class PngMapUnit;
 
 class Renderer final {
     PCS_PIMPL_DEFINITION(Renderer)
 
 public:
     struct VtkContext;
+
+    using Position = std::tuple<double, double, double>;
+
     auto vtk_context() noexcept -> VtkContext&;
 
     auto render_window() noexcept -> void;
@@ -18,6 +28,21 @@ public:
     auto connect_ui(QtVtkWindow&) noexcept -> void;
 
     auto set_background(double r, double g, double b) noexcept -> void;
+
+    auto attach_points_unit(PointsUnit const&) noexcept -> void;
+    auto detach_points_unit(PointsUnit const&) noexcept -> void;
+
+    auto attach_model_unit(ModelUnit const&) noexcept -> void;
+    auto detach_model_unit(ModelUnit const&) noexcept -> void;
+
+    auto attach_png_map_unit(PngMapUnit const&) noexcept -> void;
+    auto detach_png_map_unit(PngMapUnit const&) noexcept -> void;
+
+    auto pick_points_unit(PointsUnit const&, int display_x, int display_y) noexcept
+        -> std::optional<Position>;
+
+    auto pick_png_map_unit(PngMapUnit const&, int display_x, int display_y) noexcept
+        -> std::optional<Position>;
 };
 
 }

--- a/src/core/renderer.impl.hh
+++ b/src/core/renderer.impl.hh
@@ -2,16 +2,24 @@
 
 #include "core/renderer.hh"
 #include "core/renderer.vtk.hh"
+#include "core/units/model.hh"
+#include "core/units/png-map.hh"
+#include "core/units/points.hh"
 
 #include <spdlog/spdlog.h>
+
+#include <array>
+#include <optional>
+
+#include <vtk/vtkCellPicker.h>
+#include <vtk/vtkPointPicker.h>
 
 namespace pcs {
 
 struct Renderer::Impl {
 public:
     explicit Impl() noexcept
-        : vtk_context {} {
-
+        : vtk_context { } {
         spdlog::info("Vtk context has been created now");
     }
 
@@ -22,6 +30,71 @@ public:
 
     auto set_background(auto r, auto g, auto b) noexcept {
         vtk_context.render->SetBackground(r, g, b);
+    }
+
+    auto attach_points_unit(PointsUnit const& unit) noexcept {
+        vtk_context.attach_unit(unit.actor());
+    }
+
+    auto detach_points_unit(PointsUnit const& unit) noexcept {
+        vtk_context.detach_unit(unit.actor());
+    }
+
+    auto attach_model_unit(ModelUnit const& unit) noexcept {
+        vtk_context.attach_unit(unit.actor());
+    }
+
+    auto detach_model_unit(ModelUnit const& unit) noexcept {
+        vtk_context.detach_unit(unit.actor());
+    }
+
+    auto attach_png_map_unit(PngMapUnit const& unit) noexcept {
+        vtk_context.attach_unit(unit.actor());
+        vtk_context.attach_unit(unit.area_actor());
+    }
+
+    auto detach_png_map_unit(PngMapUnit const& unit) noexcept {
+        vtk_context.detach_unit(unit.actor());
+        vtk_context.detach_unit(unit.area_actor());
+    }
+
+    auto pick_points_unit(PointsUnit const& unit, int display_x, int display_y) noexcept
+        -> std::optional<Renderer::Position> {
+        auto picker = vtkSmartPointer<vtkPointPicker>::New();
+        picker->PickFromListOn();
+        picker->InitializePickList();
+        picker->AddPickList(unit.actor());
+
+        auto* size    = vtk_context.window->GetSize();
+        const auto ok = picker->Pick(static_cast<double>(display_x),
+            static_cast<double>(size[1] - display_y - 1), 0.0, vtk_context.render);
+        if (ok <= 0 || picker->GetPointId() < 0) {
+            return std::nullopt;
+        }
+
+        auto point = std::array<double, 3> { };
+        picker->GetPickPosition(point.data());
+        return Renderer::Position { point[0], point[1], point[2] };
+    }
+
+    auto pick_png_map_unit(PngMapUnit const& unit, int display_x, int display_y) noexcept
+        -> std::optional<Renderer::Position> {
+        auto picker = vtkSmartPointer<vtkCellPicker>::New();
+        picker->SetTolerance(0.0005);
+        picker->PickFromListOn();
+        picker->InitializePickList();
+        picker->AddPickList(unit.actor());
+
+        auto* size    = vtk_context.window->GetSize();
+        const auto ok = picker->Pick(static_cast<double>(display_x),
+            static_cast<double>(size[1] - display_y - 1), 0.0, vtk_context.render);
+        if (ok <= 0 || picker->GetCellId() < 0) {
+            return std::nullopt;
+        }
+
+        auto point = std::array<double, 3> { };
+        picker->GetPickPosition(point.data());
+        return Renderer::Position { point[0], point[1], point[2] };
     }
 
     auto get_vtk_context() -> VtkContext& { return vtk_context; }

--- a/src/core/runtime.cc
+++ b/src/core/runtime.cc
@@ -44,8 +44,8 @@ struct Runtime::Impl {
     }
 
     auto submit_task(std::unique_ptr<Task> task) noexcept {
-        // To implement
-        task->exec();
+        static_cast<co::runtime_executor&>(*work_exec).submit_task(
+            [task = std::move(task)]() mutable { task->exec(); });
     }
 };
 

--- a/src/core/units/model.cc
+++ b/src/core/units/model.cc
@@ -1,6 +1,11 @@
 #include "model.hh"
 
+#include <vtk/vtkCellArray.h>
+#include <vtk/vtkPoints.h>
+#include <vtk/vtkPolyData.h>
 #include <vtk/vtkPolyDataMapper.h>
+
+#include <array>
 
 namespace pcs {
 
@@ -9,8 +14,28 @@ struct ModelUnit::Impl {
     SmartPointer<vtkPolyDataMapper> mapper;
     SmartPointer<vtkActor> actor;
 
-    auto initialize(SmartPointer<vtkPolyData> poly_data) {
-        data = std::move(poly_data);
+    auto initialize(ModelData const& model) {
+        auto points = vtkSmartPointer<vtkPoints>::New();
+        points->SetDataTypeToDouble();
+
+        for (auto const& vertex : model.vertices) {
+            points->InsertNextPoint(vertex[0], vertex[1], vertex[2]);
+        }
+
+        auto polys = vtkSmartPointer<vtkCellArray>::New();
+        for (auto const& face : model.faces) {
+            const auto triangle = std::array<vtkIdType, 3> {
+                static_cast<vtkIdType>(face[0]),
+                static_cast<vtkIdType>(face[1]),
+                static_cast<vtkIdType>(face[2]),
+            };
+
+            polys->InsertNextCell(static_cast<vtkIdType>(triangle.size()), triangle.data());
+        }
+
+        data = vtkPolyData::New();
+        data->SetPoints(points);
+        data->SetPolys(polys);
 
         mapper = vtkPolyDataMapper::New();
         mapper->SetInputData(data);
@@ -20,16 +45,16 @@ struct ModelUnit::Impl {
     }
 };
 
-ModelUnit::ModelUnit(SmartPointer<vtkPolyData> poly_data) noexcept
+ModelUnit::ModelUnit(ModelData const& model) noexcept
     : pimpl { std::make_unique<Impl>() } {
-    initialize(std::move(poly_data));
+    initialize(model);
 }
 
-auto ModelUnit::initialize(SmartPointer<vtkPolyData> poly_data) noexcept -> void {
-    pimpl->initialize(std::move(poly_data));
-}
+auto ModelUnit::initialize(ModelData const& model) noexcept -> void { pimpl->initialize(model); }
 
 auto ModelUnit::actor() noexcept -> SmartPointer<vtkActor> { return pimpl->actor; }
+
+auto ModelUnit::actor() const noexcept -> SmartPointer<vtkActor> { return pimpl->actor; }
 
 auto ModelUnit::get_points_size() const noexcept -> std::size_t {
     return pimpl->data->GetNumberOfPoints();

--- a/src/core/units/model.hh
+++ b/src/core/units/model.hh
@@ -1,9 +1,9 @@
 #pragma once
 
 #include "common.hh"
+#include "core/map/model-data.hh"
 
 #include <vtk/vtkActor.h>
-#include <vtk/vtkPolyData.h>
 
 #include <memory>
 
@@ -11,19 +11,20 @@ namespace pcs {
 
 struct ModelUnit : public NormalUnit, TripleDUnit {
 public:
-    explicit ModelUnit(SmartPointer<vtkPolyData>) noexcept;
+    explicit ModelUnit(ModelData const&) noexcept;
     ~ModelUnit() noexcept;
 
     ModelUnit(const ModelUnit&)            = delete;
     ModelUnit& operator=(const ModelUnit&) = delete;
 
     auto actor() noexcept -> SmartPointer<vtkActor>;
+    auto actor() const noexcept -> SmartPointer<vtkActor>;
 
     auto get_points_size() const noexcept -> std::size_t;
     auto get_polys_size() const noexcept -> std::size_t;
 
 private:
-    auto initialize(SmartPointer<vtkPolyData>) noexcept -> void;
+    auto initialize(ModelData const&) noexcept -> void;
 
     struct Impl;
     std::unique_ptr<Impl> pimpl;

--- a/src/core/units/png-map.cc
+++ b/src/core/units/png-map.cc
@@ -21,6 +21,31 @@ struct PngMapUnit::Impl {
     SmartPointer<vtkActor> actor;
     SmartPointer<vtkActor> area_actor;
 
+    auto update_pixels(std::vector<std::uint8_t> const& pixels) -> bool {
+        if (image == nullptr) {
+            return false;
+        }
+
+        auto dimensions   = image->GetDimensions();
+        const auto width  = static_cast<std::size_t>(dimensions[0]);
+        const auto height = static_cast<std::size_t>(dimensions[1]);
+        if (pixels.size() != width * height) {
+            return false;
+        }
+
+        for (std::size_t y = 0; y < height; ++y) {
+            for (std::size_t x = 0; x < width; ++x) {
+                auto* pixel = static_cast<unsigned char*>(
+                    image->GetScalarPointer(static_cast<int>(x), static_cast<int>(y), 0));
+                pixel[0] = pixels[y * width + x];
+            }
+        }
+
+        image->Modified();
+        texture->Modified();
+        return true;
+    }
+
     auto initialize(PngMapData const& map) {
         image = vtkImageData::New();
         image->SetDimensions(static_cast<int>(map.width), static_cast<int>(map.height), 1);
@@ -86,9 +111,17 @@ auto PngMapUnit::actor() noexcept -> SmartPointer<vtkActor> { return pimpl->acto
 
 auto PngMapUnit::area_actor() noexcept -> SmartPointer<vtkActor> { return pimpl->area_actor; }
 
+auto PngMapUnit::actor() const noexcept -> SmartPointer<vtkActor> { return pimpl->actor; }
+
+auto PngMapUnit::area_actor() const noexcept -> SmartPointer<vtkActor> { return pimpl->area_actor; }
+
 auto PngMapUnit::set_visibility(bool on) noexcept -> void {
     pimpl->actor->SetVisibility(on);
     pimpl->area_actor->SetVisibility(on);
+}
+
+auto PngMapUnit::update_pixels(std::vector<std::uint8_t> const& pixels) noexcept -> bool {
+    return pimpl->update_pixels(pixels);
 }
 
 PngMapUnit::~PngMapUnit() noexcept = default;

--- a/src/core/units/png-map.hh
+++ b/src/core/units/png-map.hh
@@ -17,8 +17,11 @@ public:
 
     auto actor() noexcept -> SmartPointer<vtkActor>;
     auto area_actor() noexcept -> SmartPointer<vtkActor>;
+    auto actor() const noexcept -> SmartPointer<vtkActor>;
+    auto area_actor() const noexcept -> SmartPointer<vtkActor>;
 
     auto set_visibility(bool on) noexcept -> void;
+    auto update_pixels(std::vector<std::uint8_t> const& pixels) noexcept -> bool;
 
 private:
     auto initialize(PngMapData const&) noexcept -> void;

--- a/src/core/units/points.cc
+++ b/src/core/units/points.cc
@@ -39,6 +39,8 @@ auto PointsUnit::initialize(SmartPointer<vtkPoints> points) noexcept -> void {
 
 auto PointsUnit::actor() noexcept -> SmartPointer<vtkActor> { return pimpl->actor; }
 
+auto PointsUnit::actor() const noexcept -> SmartPointer<vtkActor> { return pimpl->actor; }
+
 auto PointsUnit::get_points_size() const noexcept -> std::size_t {
     return pimpl->points->GetNumberOfPoints();
 }

--- a/src/core/units/points.hh
+++ b/src/core/units/points.hh
@@ -80,7 +80,7 @@ public:
     template <class Points>
         requires details::unit::points::points_trait<Points>
     explicit PointsUnit(Points const& points) noexcept
-        : pcs::PointsUnit {} {
+        : pcs::PointsUnit { } {
         using namespace details::unit::points;
 
         auto vtk_points = vtkPoints::New();
@@ -92,6 +92,7 @@ public:
     }
 
     auto actor() noexcept -> SmartPointer<vtkActor>;
+    auto actor() const noexcept -> SmartPointer<vtkActor>;
 
     auto get_points_size() const noexcept -> std::size_t;
 

--- a/src/gui/app.cc
+++ b/src/gui/app.cc
@@ -1,9 +1,8 @@
 #include "app.hh"
 
-#include "core/assets.hh"
-#include "core/renderer.hh"
-#include "core/runtime.hh"
-
+#include "gui/context/features.hh"
+#include "gui/context/modules.hh"
+#include "gui/context/states.hh"
 #include "gui/navigation.hh"
 #include "gui/visualization-window.hh"
 #include "gui/working-panel.hh"
@@ -45,9 +44,8 @@ public:
 
         // App modules loading
         {
-            runtime  = std::make_unique<Runtime>();
-            renderer = std::make_unique<Renderer>();
-            assets   = std::make_unique<AssetsManager>(*renderer);
+            modules = gui::context::make_app_modules();
+            gui::context::register_default_features(modules);
 
             sp::info("App modules are loaded");
         }
@@ -58,11 +56,21 @@ public:
             manager->set_theme_pack(kBlueMikuThemePack);
             manager->set_color_mode(ColorMode::LIGHT);
 
+            states = gui::context::make_app_states(*manager, modules);
+
             {
-                navigation_state = std::make_unique<NavigationState>(*manager);
+                navigation_state = std::move(states.navigation);
 
                 navigation_state->icon_font     = material::round::font;
+                navigation_state->mouse         = modules.mouse.get();
                 navigation_state->function_quit = [this] { exit_application_with_confirment(); };
+                navigation_state->picker_mode_getter = [this] {
+                    return modules.mouse->mode() == gui::interaction::MouseModeId::Picker;
+                };
+                navigation_state->picker_mode_setter = [this](bool on) {
+                    modules.mouse->set_mode(on ? gui::interaction::MouseModeId::Picker
+                                               : gui::interaction::MouseModeId::None);
+                };
 
                 auto& contexts = navigation_state->buttons_context;
                 contexts.emplace_back("3d window", "home", [this] { });
@@ -70,24 +78,23 @@ public:
                     "switch theme", "format_paint", [this] { switch_next_theme(); });
             }
             {
-                visualization_window_state =
-                    std::make_unique<VisualizationWindowState>(*manager, *renderer);
+                visualization_window_state = std::move(states.visualization);
             }
             {
-                working_panel_state =
-                    std::make_unique<WorkingPanelState>(*manager, *assets, *renderer);
+                working_panel_state = std::move(states.working);
             }
 
             window = MainWindowComponent();
 
             const auto& colorscheme = manager->theme_pack().dark;
             const auto& background  = colorscheme.background;
-            renderer->set_background(background.redF(), background.greenF(), background.blueF());
+            modules.renderer->set_background(
+                background.redF(), background.greenF(), background.blueF());
 
             const auto point = colorscheme.primary;
-            assets->set_default_point_color(point.redF(), point.greenF(), point.blueF());
+            modules.assets->set_default_point_color(point.redF(), point.greenF(), point.blueF());
 
-            renderer->render_window();
+            modules.renderer->render_window();
 
             manager->apply_theme();
 
@@ -123,11 +130,10 @@ private:
     std::unique_ptr<NavigationState> navigation_state;
     std::unique_ptr<VisualizationWindowState> visualization_window_state;
     std::unique_ptr<WorkingPanelState> working_panel_state;
+    gui::context::AppStates states;
 
     std::unique_ptr<ThemeManager> manager;
-    std::unique_ptr<Runtime> runtime;
-    std::unique_ptr<Renderer> renderer;
-    std::unique_ptr<AssetsManager> assets;
+    gui::context::AppModules modules;
 
     auto MainWindowComponent() noexcept -> QPointer<MainWindow> {
         namespace mwp = main_window::pro;

--- a/src/gui/context/features.cc
+++ b/src/gui/context/features.cc
@@ -1,0 +1,191 @@
+#include "gui/context/features.hh"
+
+#include "core/events/render/model.hh"
+#include "core/events/render/points.hh"
+#include "gui/interaction/picker-mode.hh"
+#include "gui/interaction/picker-png-map-extension.hh"
+#include "gui/interaction/picker-pointcloud-extension.hh"
+#include "gui/interaction/png-edit-mode.hh"
+#include "gui/working/panels/model-panel.hh"
+#include "gui/working/panels/png-map-panel.hh"
+#include "gui/working/panels/pointcloud-panel.hh"
+
+#include <filesystem>
+
+namespace pcs::gui::context {
+
+namespace {
+
+auto inferred_name(std::string const& path, std::string_view fallback) -> std::string {
+    auto name = std::filesystem::path(path).filename().string();
+    if (name.empty()) {
+        return std::string { fallback };
+    }
+    return name;
+}
+
+auto trim_decimal_zeros(QString text) noexcept -> QString {
+    while (text.contains('.') && text.endsWith('0')) {
+        text.chop(1);
+    }
+    if (text.endsWith('.')) {
+        text.chop(1);
+    }
+    if (text == "-0") {
+        return "0";
+    }
+    return text;
+}
+
+auto format_size_mb(std::uintmax_t bytes) noexcept -> QString {
+    const auto mb = static_cast<double>(bytes) / (1024.0 * 1024.0);
+    return trim_decimal_zeros(QString::number(mb, 'f', 2));
+}
+
+auto asset_size_mb_text(std::string const& path, std::uintmax_t fallback_bytes) noexcept -> QString {
+    if (!path.empty() && path != "<memory>") {
+        auto error      = std::error_code { };
+        const auto size = std::filesystem::file_size(path, error);
+        if (!error) {
+            return format_size_mb(size);
+        }
+    }
+
+    return format_size_mb(fallback_bytes);
+}
+
+}
+
+auto register_default_features(AppModules& modules) noexcept -> void {
+    auto picker_mode = std::make_unique<gui::interaction::PickerMode>(
+        *modules.renderer, *modules.assets);
+    picker_mode->register_extension(gui::interaction::make_pointcloud_picker_extension());
+    picker_mode->register_extension(gui::interaction::make_png_map_picker_extension());
+
+    modules.mouse->register_mode(std::move(picker_mode));
+    modules.mouse->register_mode(
+        std::make_unique<gui::interaction::PngEditMode>(*modules.renderer, *modules.assets));
+
+    modules.action_panels->register_factory(pcs::AssetKind::Pointcloud,
+        [](gui::working::ActionPanelContext context, QFont const& font) {
+            return gui::working::make_pointcloud_panel(std::move(context), font);
+        });
+    modules.action_panels->register_factory(pcs::AssetKind::Model,
+        [](gui::working::ActionPanelContext context, QFont const& font) {
+            return gui::working::make_model_panel(std::move(context), font);
+        });
+    modules.action_panels->register_factory(pcs::AssetKind::PngMap,
+        [](gui::working::ActionPanelContext context, QFont const& font) {
+            return gui::working::make_png_map_panel(std::move(context), font);
+        });
+
+    modules.asset_details->register_provider(pcs::AssetKind::Pointcloud,
+        [](pcs::AssetsManager& assets, std::string const& id)
+            -> std::optional<pcs::gui::working::AssetDetails> {
+            auto result = assets.get_pointcloud_handle(id);
+            if (!result.has_value()) {
+                return std::nullopt;
+            }
+
+            auto* handle               = result.value();
+            const auto points_count    = static_cast<std::uintmax_t>(handle->get_points_size());
+            const auto path            = assets.get_asset_path(id).value_or(std::string { });
+            const auto estimated_bytes = points_count * 3U * sizeof(float);
+            const auto is_memory       = path == "<memory>";
+
+            return pcs::gui::working::AssetDetails {
+                .type = "点云",
+                .size = asset_size_mb_text(path, estimated_bytes),
+                .info = QString("点数: %1 点, 状态: %2")
+                            .arg(static_cast<qulonglong>(points_count))
+                            .arg(is_memory ? "内存中" : "已保存"),
+            };
+        });
+    modules.asset_details->register_provider(pcs::AssetKind::Model,
+        [](pcs::AssetsManager& assets, std::string const& id)
+            -> std::optional<pcs::gui::working::AssetDetails> {
+            auto result = assets.get_model_handle(id);
+            if (!result.has_value()) {
+                return std::nullopt;
+            }
+
+            auto* handle        = result.value();
+            const auto vertices = static_cast<std::uintmax_t>(handle->get_points_size());
+            const auto faces    = static_cast<std::uintmax_t>(handle->get_polys_size());
+            const auto path     = assets.get_asset_path(id).value_or(std::string { });
+            const auto estimated_bytes =
+                vertices * 3U * sizeof(float) + faces * 3U * sizeof(std::uint32_t);
+
+            return pcs::gui::working::AssetDetails {
+                .type = "模型",
+                .size = asset_size_mb_text(path, estimated_bytes),
+                .info = QString("顶点: %1 点, 面数: %2 面")
+                            .arg(static_cast<qulonglong>(vertices))
+                            .arg(static_cast<qulonglong>(faces)),
+            };
+        });
+    modules.asset_details->register_provider(pcs::AssetKind::PngMap,
+        [](pcs::AssetsManager& assets, std::string const& id)
+            -> std::optional<pcs::gui::working::AssetDetails> {
+            auto result = assets.get_png_map_handle(id);
+            if (!result.has_value()) {
+                return std::nullopt;
+            }
+
+            auto* handle      = result.value();
+            const auto width  = static_cast<std::uintmax_t>(handle->get_width());
+            const auto height = static_cast<std::uintmax_t>(handle->get_height());
+            const auto path   = assets.get_asset_path(id).value_or(std::string { });
+
+            return pcs::gui::working::AssetDetails {
+                .type = "PNG 地图",
+                .size = asset_size_mb_text(path, width * height),
+                .info = QString("尺寸: %1 x %2 像素, 分辨率: %3 米/像素, Z: %4")
+                            .arg(static_cast<qulonglong>(width))
+                            .arg(static_cast<qulonglong>(height))
+                            .arg(handle->get_resolution(), 0, 'f', 3)
+                            .arg(handle->get_plane_z(), 0, 'f', 3),
+            };
+        });
+
+    modules.open_control->register_format({
+        .label          = "点云文件",
+        .dialog_pattern = "*.pcd",
+        .extensions     = { ".pcd" },
+        .open           = [&modules](std::string const& path) -> std::expected<void, std::string> {
+            auto context = std::make_unique<pcs::event::MakePointsUnit::Context>();
+            context->path = path;
+            context->name = inferred_name(path, "pointcloud.pcd");
+
+            auto result = pcs::event::MakePointsUnit::runtime_exec(std::move(context));
+            if (!result.has_value()) {
+                return std::unexpected { result.error() };
+            }
+
+            modules.assets->register_pointcloud_asset(
+                std::move(result.value()), inferred_name(path, "pointcloud.pcd"), path, true);
+            return { };
+        },
+    });
+    modules.open_control->register_format({
+        .label          = "模型文件",
+        .dialog_pattern = "*.obj",
+        .extensions     = { ".obj" },
+        .open           = [&modules](std::string const& path) -> std::expected<void, std::string> {
+            auto context = std::make_unique<pcs::event::MakeModelUnit::Context>();
+            context->path = path;
+            context->name = inferred_name(path, "model.obj");
+
+            auto result = pcs::event::MakeModelUnit::runtime_exec(std::move(context));
+            if (!result.has_value()) {
+                return std::unexpected { result.error() };
+            }
+
+            modules.assets->register_model_asset(
+                std::move(result.value()), inferred_name(path, "model.obj"), path);
+            return { };
+        },
+    });
+}
+
+}

--- a/src/gui/context/features.hh
+++ b/src/gui/context/features.hh
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "gui/context/modules.hh"
+
+namespace pcs::gui::context {
+
+auto register_default_features(AppModules&) noexcept -> void;
+
+}

--- a/src/gui/context/modules.cc
+++ b/src/gui/context/modules.cc
@@ -1,0 +1,17 @@
+#include "gui/context/modules.hh"
+
+namespace pcs::gui::context {
+
+auto make_app_modules() noexcept -> AppModules {
+    auto modules         = AppModules { };
+    modules.runtime      = std::make_unique<pcs::Runtime>();
+    modules.renderer     = std::make_unique<pcs::Renderer>();
+    modules.assets       = std::make_unique<pcs::AssetsManager>(*modules.renderer);
+    modules.mouse        = std::make_unique<pcs::gui::interaction::Mouse>();
+    modules.action_panels = std::make_unique<pcs::gui::working::ActionPanelRegistry>();
+    modules.open_control = std::make_unique<pcs::gui::working::OpenControl>();
+    modules.asset_details = std::make_unique<pcs::gui::working::AssetDetailsRegistry>();
+    return modules;
+}
+
+}

--- a/src/gui/context/modules.hh
+++ b/src/gui/context/modules.hh
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "core/assets.hh"
+#include "core/renderer.hh"
+#include "core/runtime.hh"
+#include "gui/interaction/mouse.hh"
+#include "gui/working/action-panels.hh"
+#include "gui/working/asset-details.hh"
+#include "gui/working/open-control.hh"
+
+#include <memory>
+
+namespace pcs::gui::context {
+
+struct AppModules {
+    std::unique_ptr<pcs::Runtime> runtime;
+    std::unique_ptr<pcs::Renderer> renderer;
+    std::unique_ptr<pcs::AssetsManager> assets;
+    std::unique_ptr<pcs::gui::interaction::Mouse> mouse;
+    std::unique_ptr<pcs::gui::working::ActionPanelRegistry> action_panels;
+    std::unique_ptr<pcs::gui::working::OpenControl> open_control;
+    std::unique_ptr<pcs::gui::working::AssetDetailsRegistry> asset_details;
+};
+
+auto make_app_modules() noexcept -> AppModules;
+
+}

--- a/src/gui/context/states.cc
+++ b/src/gui/context/states.cc
@@ -1,0 +1,23 @@
+#include "gui/context/states.hh"
+
+namespace pcs::gui::context {
+
+auto make_app_states(creeper::ThemeManager& manager, AppModules& modules) noexcept -> AppStates {
+    auto states          = AppStates { };
+    states.navigation    = std::make_unique<NavigationState>(manager);
+    states.visualization =
+        std::make_unique<VisualizationWindowState>(manager, *modules.renderer);
+    states.working = std::make_unique<WorkingPanelState>(
+        manager, *modules.assets, *modules.runtime, *modules.renderer);
+
+    states.navigation->mouse = modules.mouse.get();
+    states.visualization->mouse = modules.mouse.get();
+    states.working->mouse = modules.mouse.get();
+    states.working->open_control = modules.open_control.get();
+    states.working->action_panel_registry = modules.action_panels.get();
+    states.working->asset_details_registry = modules.asset_details.get();
+
+    return states;
+}
+
+}

--- a/src/gui/context/states.hh
+++ b/src/gui/context/states.hh
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "gui/context/modules.hh"
+#include "gui/navigation.hh"
+#include "gui/visualization-window.hh"
+#include "gui/working-panel.hh"
+
+#include <memory>
+
+namespace pcs::gui::context {
+
+struct AppStates {
+    std::unique_ptr<NavigationState> navigation;
+    std::unique_ptr<VisualizationWindowState> visualization;
+    std::unique_ptr<WorkingPanelState> working;
+};
+
+auto make_app_states(creeper::ThemeManager& manager, AppModules& modules) noexcept -> AppStates;
+
+}

--- a/src/gui/interaction/mouse.cc
+++ b/src/gui/interaction/mouse.cc
@@ -1,0 +1,195 @@
+#include "gui/interaction/mouse.hh"
+
+#include <utility>
+
+namespace pcs::gui::interaction {
+
+auto Mouse::register_mode(std::unique_ptr<MouseMode> mode) noexcept -> void {
+    if (mode == nullptr) {
+        return;
+    }
+
+    modes[mode->id()] = std::move(mode);
+}
+
+auto Mouse::set_mode(MouseModeId mode) noexcept -> void {
+    if (current_mode == mode) {
+        return;
+    }
+
+    if (auto iter = modes.find(current_mode); iter != modes.end() && iter->second != nullptr) {
+        iter->second->on_exit(*this);
+    }
+
+    clear_handlers();
+    current_mode = mode;
+
+    if (auto iter = modes.find(current_mode); iter != modes.end() && iter->second != nullptr) {
+        iter->second->on_init(*this);
+    }
+
+    if (mode_sink) {
+        mode_sink(current_mode);
+    }
+}
+
+auto Mouse::mode() const noexcept -> MouseModeId { return current_mode; }
+
+auto Mouse::allows_camera_interaction() const noexcept -> bool {
+    auto iter = modes.find(current_mode);
+    if (iter == modes.end() || iter->second == nullptr) {
+        return true;
+    }
+
+    return iter->second->allows_camera_interaction(*this);
+}
+
+auto Mouse::on_move(Handler handler) noexcept -> Token {
+    return add_handler(move_handlers, std::move(handler));
+}
+
+auto Mouse::on_lclick(Handler handler) noexcept -> Token {
+    return add_handler(lclick_handlers, std::move(handler));
+}
+
+auto Mouse::on_rclick(Handler handler) noexcept -> Token {
+    return add_handler(rclick_handlers, std::move(handler));
+}
+
+auto Mouse::off(Token token) noexcept -> bool {
+    if (move_handlers.erase(token) > 0) {
+        return true;
+    }
+    if (lclick_handlers.erase(token) > 0) {
+        return true;
+    }
+    if (rclick_handlers.erase(token) > 0) {
+        return true;
+    }
+    return false;
+}
+
+auto Mouse::clear_handlers() noexcept -> void {
+    move_handlers.clear();
+    lclick_handlers.clear();
+    rclick_handlers.clear();
+}
+
+auto Mouse::emit_move(MouseEvent const& event) noexcept -> void {
+    emit_handlers(move_handlers, event);
+}
+
+auto Mouse::emit_lclick(MouseEvent const& event) noexcept -> void {
+    emit_handlers(lclick_handlers, event);
+}
+
+auto Mouse::emit_rclick(MouseEvent const& event) noexcept -> void {
+    emit_handlers(rclick_handlers, event);
+}
+
+auto Mouse::set_status_sink(std::function<void(QString const&)> sink) noexcept -> void {
+    status_sink = std::move(sink);
+    if (status_sink) {
+        status_sink(status_text);
+    }
+}
+
+auto Mouse::set_status(QString text) noexcept -> void {
+    status_text = std::move(text);
+    if (status_sink) {
+        status_sink(status_text);
+    }
+}
+
+auto Mouse::status() const noexcept -> QString const& { return status_text; }
+
+auto Mouse::set_mode_sink(std::function<void(MouseModeId)> sink) noexcept -> void {
+    mode_sink = std::move(sink);
+    if (mode_sink) {
+        mode_sink(current_mode);
+    }
+}
+
+auto Mouse::set_png_edit_tool_sink(std::function<void(PngEditTool)> sink) noexcept -> void {
+    png_edit_tool_sink = std::move(sink);
+    if (png_edit_tool_sink) {
+        png_edit_tool_sink(png_edit_tool_mode);
+    }
+}
+
+auto Mouse::set_png_edit_line_width(std::size_t width) noexcept -> void {
+    png_edit_line_width_px = std::max<std::size_t>(width, 1);
+}
+
+auto Mouse::png_edit_line_width() const noexcept -> std::size_t { return png_edit_line_width_px; }
+
+auto Mouse::set_png_edit_point_size(std::size_t size) noexcept -> void {
+    png_edit_point_size_px = std::max<std::size_t>(size, 1);
+}
+
+auto Mouse::png_edit_point_size() const noexcept -> std::size_t { return png_edit_point_size_px; }
+
+auto Mouse::set_png_edit_erase_size(std::size_t size) noexcept -> void {
+    png_edit_erase_size_px = std::max<std::size_t>(size, 1);
+}
+
+auto Mouse::png_edit_erase_size() const noexcept -> std::size_t { return png_edit_erase_size_px; }
+
+auto Mouse::set_png_edit_tool(PngEditTool tool) noexcept -> void {
+    png_edit_tool_mode = tool;
+    if (png_edit_tool_sink) {
+        png_edit_tool_sink(png_edit_tool_mode);
+    }
+}
+
+auto Mouse::png_edit_tool() const noexcept -> PngEditTool { return png_edit_tool_mode; }
+
+auto Mouse::set_selected_asset(std::string id, pcs::AssetKind kind) noexcept -> void {
+    asset = MouseSelection {
+        .id   = std::move(id),
+        .kind = kind,
+    };
+
+    auto iter = modes.find(current_mode);
+    if (iter != modes.end() && iter->second != nullptr && !iter->second->supports_selection(asset)) {
+        set_mode(MouseModeId::None);
+    }
+}
+
+auto Mouse::clear_selected_asset() noexcept -> void {
+    asset.reset();
+
+    auto iter = modes.find(current_mode);
+    if (iter != modes.end() && iter->second != nullptr && !iter->second->supports_selection(asset)) {
+        set_mode(MouseModeId::None);
+    }
+}
+
+auto Mouse::selected_asset() const noexcept -> std::optional<MouseSelection> const& { return asset; }
+
+auto Mouse::next_token() noexcept -> Token {
+    ++last_token;
+    return last_token;
+}
+
+auto Mouse::add_handler(
+    std::unordered_map<Token, HandlerEntry>& handlers, Handler callback) noexcept -> Token {
+    auto token = next_token();
+    handlers.emplace(token,
+        HandlerEntry {
+            .mode     = current_mode,
+            .callback = std::move(callback),
+        });
+    return token;
+}
+
+auto Mouse::emit_handlers(std::unordered_map<Token, HandlerEntry> const& handlers,
+    MouseEvent const& event) const noexcept -> void {
+    for (auto const& [_, entry] : handlers) {
+        if (entry.callback) {
+            entry.callback(event);
+        }
+    }
+}
+
+}

--- a/src/gui/interaction/mouse.hh
+++ b/src/gui/interaction/mouse.hh
@@ -1,0 +1,134 @@
+#pragma once
+
+#include "core/assets.hh"
+
+#include <qnamespace.h>
+#include <qstring.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+#include <unordered_map>
+
+namespace pcs::gui::interaction {
+
+enum class MouseModeId {
+    None,
+    Picker,
+    PngEdit,
+};
+
+enum class PngEditTool {
+    Free,
+    Line,
+    Point,
+    Erase,
+};
+
+struct MouseEvent {
+    int x = 0;
+    int y = 0;
+    Qt::KeyboardModifiers modifiers { };
+    Qt::MouseButtons buttons { };
+};
+
+struct MouseSelection {
+    std::string id;
+    pcs::AssetKind kind = pcs::AssetKind::Pointcloud;
+};
+
+class Mouse;
+
+struct MouseMode {
+    virtual ~MouseMode() = default;
+
+    virtual auto id() const noexcept -> MouseModeId = 0;
+    virtual auto on_init(Mouse&) noexcept -> void { }
+    virtual auto on_exit(Mouse&) noexcept -> void { }
+    virtual auto supports_selection(std::optional<MouseSelection> const&) const noexcept -> bool {
+        return true;
+    }
+    virtual auto allows_camera_interaction(Mouse const&) const noexcept -> bool { return true; }
+};
+
+class Mouse final {
+public:
+    using Handler = std::function<void(MouseEvent const&)>;
+    using Token   = std::size_t;
+
+    auto register_mode(std::unique_ptr<MouseMode>) noexcept -> void;
+
+    auto set_mode(MouseModeId) noexcept -> void;
+    auto mode() const noexcept -> MouseModeId;
+    auto allows_camera_interaction() const noexcept -> bool;
+
+    auto on_move(Handler) noexcept -> Token;
+    auto on_lclick(Handler) noexcept -> Token;
+    auto on_rclick(Handler) noexcept -> Token;
+    auto off(Token) noexcept -> bool;
+    auto clear_handlers() noexcept -> void;
+
+    auto emit_move(MouseEvent const&) noexcept -> void;
+    auto emit_lclick(MouseEvent const&) noexcept -> void;
+    auto emit_rclick(MouseEvent const&) noexcept -> void;
+
+    auto set_status_sink(std::function<void(QString const&)>) noexcept -> void;
+    auto set_status(QString) noexcept -> void;
+    auto status() const noexcept -> QString const&;
+
+    auto set_mode_sink(std::function<void(MouseModeId)>) noexcept -> void;
+    auto set_png_edit_tool_sink(std::function<void(PngEditTool)>) noexcept -> void;
+
+    auto set_png_edit_line_width(std::size_t) noexcept -> void;
+    auto png_edit_line_width() const noexcept -> std::size_t;
+
+    auto set_png_edit_point_size(std::size_t) noexcept -> void;
+    auto png_edit_point_size() const noexcept -> std::size_t;
+
+    auto set_png_edit_erase_size(std::size_t) noexcept -> void;
+    auto png_edit_erase_size() const noexcept -> std::size_t;
+
+    auto set_png_edit_tool(PngEditTool) noexcept -> void;
+    auto png_edit_tool() const noexcept -> PngEditTool;
+
+    auto set_selected_asset(std::string id, pcs::AssetKind kind) noexcept -> void;
+    auto clear_selected_asset() noexcept -> void;
+    auto selected_asset() const noexcept -> std::optional<MouseSelection> const&;
+
+private:
+    struct HandlerEntry {
+        MouseModeId mode = MouseModeId::None;
+        Handler callback;
+    };
+
+    auto next_token() noexcept -> Token;
+    auto add_handler(std::unordered_map<Token, HandlerEntry>&, Handler) noexcept -> Token;
+    auto emit_handlers(
+        std::unordered_map<Token, HandlerEntry> const&, MouseEvent const&) const noexcept -> void;
+
+    std::unordered_map<MouseModeId, std::unique_ptr<MouseMode>> modes;
+    MouseModeId current_mode = MouseModeId::None;
+
+    std::unordered_map<Token, HandlerEntry> move_handlers;
+    std::unordered_map<Token, HandlerEntry> lclick_handlers;
+    std::unordered_map<Token, HandlerEntry> rclick_handlers;
+
+    Token last_token = 0;
+
+    QString status_text = "就绪";
+    std::function<void(QString const&)> status_sink;
+    std::function<void(MouseModeId)> mode_sink;
+    std::function<void(PngEditTool)> png_edit_tool_sink;
+
+    std::size_t png_edit_line_width_px = 3;
+    std::size_t png_edit_point_size_px = 4;
+    std::size_t png_edit_erase_size_px = 10;
+    PngEditTool png_edit_tool_mode     = PngEditTool::Free;
+
+    std::optional<MouseSelection> asset;
+};
+
+}

--- a/src/gui/interaction/picker-extension.hh
+++ b/src/gui/interaction/picker-extension.hh
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "core/assets.hh"
+#include "core/renderer.hh"
+#include "gui/interaction/mouse.hh"
+
+#include <string>
+
+namespace pcs::gui::interaction {
+
+struct PickerExtension {
+    virtual ~PickerExtension() = default;
+
+    virtual auto kind() const noexcept -> pcs::AssetKind = 0;
+
+    virtual auto pick(Mouse&, MouseEvent const&, std::string const& asset_id, Renderer&,
+        AssetsManager&) noexcept -> void = 0;
+};
+
+}

--- a/src/gui/interaction/picker-mode.cc
+++ b/src/gui/interaction/picker-mode.cc
@@ -1,0 +1,53 @@
+#include "gui/interaction/picker-mode.hh"
+
+namespace pcs::gui::interaction {
+
+PickerMode::PickerMode(Renderer& renderer, AssetsManager& assets) noexcept
+    : renderer { renderer }
+    , assets { assets } { }
+
+auto PickerMode::register_extension(std::unique_ptr<PickerExtension> extension) noexcept -> void {
+    if (extension == nullptr) {
+        return;
+    }
+
+    extensions[extension->kind()] = std::move(extension);
+}
+
+auto PickerMode::id() const noexcept -> MouseModeId { return MouseModeId::Picker; }
+
+auto PickerMode::on_init(Mouse& mouse) noexcept -> void {
+    next_move_pick_at = std::chrono::steady_clock::time_point::min();
+    mouse.set_status("拾取模式：移动鼠标查看坐标");
+
+    mouse.on_move([this, &mouse](MouseEvent const& event) {
+        const auto now = std::chrono::steady_clock::now();
+        if (now < next_move_pick_at) {
+            return;
+        }
+
+        next_move_pick_at = now + kMovePickInterval;
+        pick(mouse, event);
+    });
+
+    mouse.on_lclick([this, &mouse](MouseEvent const& event) { pick(mouse, event); });
+}
+
+auto PickerMode::on_exit(Mouse& mouse) noexcept -> void { mouse.set_status("拾取模式：已关闭"); }
+
+auto PickerMode::pick(Mouse& mouse, MouseEvent const& event) noexcept -> void {
+    const auto& selected = mouse.selected_asset();
+    if (!selected.has_value()) {
+        mouse.set_status("拾取模式：未选择资产");
+        return;
+    }
+
+    auto extension = extensions.find(selected->kind);
+    if (extension == extensions.end() || extension->second == nullptr) {
+        return;
+    }
+
+    extension->second->pick(mouse, event, selected->id, renderer, assets);
+}
+
+}

--- a/src/gui/interaction/picker-mode.hh
+++ b/src/gui/interaction/picker-mode.hh
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "core/assets.hh"
+#include "core/renderer.hh"
+#include "gui/interaction/mouse.hh"
+#include "gui/interaction/picker-extension.hh"
+
+#include <chrono>
+#include <memory>
+#include <unordered_map>
+
+namespace pcs::gui::interaction {
+
+class PickerMode final : public MouseMode {
+public:
+    PickerMode(Renderer&, AssetsManager&) noexcept;
+
+    auto register_extension(std::unique_ptr<PickerExtension>) noexcept -> void;
+
+    auto id() const noexcept -> MouseModeId override;
+    auto on_init(Mouse&) noexcept -> void override;
+    auto on_exit(Mouse&) noexcept -> void override;
+
+private:
+    auto pick(Mouse&, MouseEvent const&) noexcept -> void;
+
+    Renderer& renderer;
+    AssetsManager& assets;
+    std::unordered_map<pcs::AssetKind, std::unique_ptr<PickerExtension>> extensions;
+
+    std::chrono::steady_clock::time_point next_move_pick_at;
+    static constexpr auto kMovePickInterval = std::chrono::milliseconds { 100 };
+};
+
+}

--- a/src/gui/interaction/picker-png-map-extension.cc
+++ b/src/gui/interaction/picker-png-map-extension.cc
@@ -1,0 +1,48 @@
+#include "gui/interaction/picker-png-map-extension.hh"
+
+#include "core/handle/png-map.hh"
+
+#include <array>
+
+namespace pcs::gui::interaction {
+
+namespace {
+
+    auto format_xyz(double const* p) noexcept -> QString {
+        return QString("x=%1, y=%2, z=%3")
+            .arg(p[0], 0, 'f', 4)
+            .arg(p[1], 0, 'f', 4)
+            .arg(p[2], 0, 'f', 4);
+    }
+
+    class PngMapPickerExtension final : public PickerExtension {
+    public:
+        auto kind() const noexcept -> pcs::AssetKind override { return pcs::AssetKind::PngMap; }
+
+        auto pick(Mouse& mouse, MouseEvent const& event, std::string const& asset_id,
+            Renderer& renderer, AssetsManager& assets) noexcept -> void override {
+            auto handle = assets.get_png_map_handle(asset_id);
+            if (!handle.has_value() || handle.value() == nullptr) {
+                mouse.set_status("拾取模式：PNG 地图不可用");
+                return;
+            }
+
+            auto position = handle.value()->pick_plane_position(renderer, event.x, event.y);
+            if (!position.has_value()) {
+                mouse.set_status("拾取模式：未命中地图平面");
+                return;
+            }
+
+            const auto [x, y, z] = *position;
+            const auto value     = std::array<double, 3> { x, y, z };
+            mouse.set_status(QString("平面 | %1").arg(format_xyz(value.data())));
+        }
+    };
+
+}
+
+auto make_png_map_picker_extension() -> std::unique_ptr<PickerExtension> {
+    return std::make_unique<PngMapPickerExtension>();
+}
+
+}

--- a/src/gui/interaction/picker-png-map-extension.hh
+++ b/src/gui/interaction/picker-png-map-extension.hh
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "gui/interaction/picker-extension.hh"
+
+#include <memory>
+
+namespace pcs::gui::interaction {
+
+auto make_png_map_picker_extension() -> std::unique_ptr<PickerExtension>;
+
+}

--- a/src/gui/interaction/picker-pointcloud-extension.cc
+++ b/src/gui/interaction/picker-pointcloud-extension.cc
@@ -1,0 +1,48 @@
+#include "gui/interaction/picker-pointcloud-extension.hh"
+
+#include "core/handle/points.hh"
+
+#include <array>
+
+namespace pcs::gui::interaction {
+
+namespace {
+
+    auto format_xyz(double const* p) noexcept -> QString {
+        return QString("x=%1, y=%2, z=%3")
+            .arg(p[0], 0, 'f', 4)
+            .arg(p[1], 0, 'f', 4)
+            .arg(p[2], 0, 'f', 4);
+    }
+
+    class PointcloudPickerExtension final : public PickerExtension {
+    public:
+        auto kind() const noexcept -> pcs::AssetKind override { return pcs::AssetKind::Pointcloud; }
+
+        auto pick(Mouse& mouse, MouseEvent const& event, std::string const& asset_id,
+            Renderer& renderer, AssetsManager& assets) noexcept -> void override {
+            auto handle = assets.get_pointcloud_handle(asset_id);
+            if (!handle.has_value() || handle.value() == nullptr) {
+                mouse.set_status("拾取模式：点云不可用");
+                return;
+            }
+
+            auto position = handle.value()->pick_position(renderer, event.x, event.y);
+            if (!position.has_value()) {
+                mouse.set_status("拾取模式：未命中点云点");
+                return;
+            }
+
+            const auto [x, y, z] = *position;
+            const auto value     = std::array<double, 3> { x, y, z };
+            mouse.set_status(QString("点 | %1").arg(format_xyz(value.data())));
+        }
+    };
+
+}
+
+auto make_pointcloud_picker_extension() -> std::unique_ptr<PickerExtension> {
+    return std::make_unique<PointcloudPickerExtension>();
+}
+
+}

--- a/src/gui/interaction/picker-pointcloud-extension.hh
+++ b/src/gui/interaction/picker-pointcloud-extension.hh
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "gui/interaction/picker-extension.hh"
+
+#include <memory>
+
+namespace pcs::gui::interaction {
+
+auto make_pointcloud_picker_extension() -> std::unique_ptr<PickerExtension>;
+
+}

--- a/src/gui/interaction/png-edit-mode.cc
+++ b/src/gui/interaction/png-edit-mode.cc
@@ -1,0 +1,441 @@
+#include "gui/interaction/png-edit-mode.hh"
+
+#include "core/handle/png-map.hh"
+#include "gui/interaction/png-edit-tools.hh"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+
+namespace pcs::gui::interaction {
+
+namespace {
+
+    auto format_xyz(double const* p) noexcept -> QString {
+        return QString("x=%1, y=%2, z=%3")
+            .arg(p[0], 0, 'f', 4)
+            .arg(p[1], 0, 'f', 4)
+            .arg(p[2], 0, 'f', 4);
+    }
+
+    auto mode_status(Mouse const& mouse, QString const& detail = { }) noexcept -> QString {
+        auto text = QString("PNG 编辑 | 模式: %1")
+                        .arg(png_edit_tool_descriptor(mouse.png_edit_tool()).label);
+        if (!detail.isEmpty()) {
+            text += " | ";
+            text += detail;
+        }
+        return text;
+    }
+
+    auto to_pixel(PngMapHandle const& handle, PngMapHandle::Position const& world) noexcept
+        -> std::optional<PixelPoint> {
+        const auto [wx, wy, _] = world;
+
+        const auto resolution = handle.get_resolution();
+        if (resolution <= 0.0) {
+            return std::nullopt;
+        }
+
+        const auto px = static_cast<int>(std::llround((wx - handle.get_origin_x()) / resolution));
+        const auto py = static_cast<int>(std::llround((wy - handle.get_origin_y()) / resolution));
+
+        if (px < 0 || py < 0) {
+            return std::nullopt;
+        }
+
+        if (static_cast<std::size_t>(px) >= handle.get_width()
+            || static_cast<std::size_t>(py) >= handle.get_height()) {
+            return std::nullopt;
+        }
+
+        return PixelPoint { px, py };
+    }
+
+    auto from_pixel(PngMapHandle const& handle, PixelPoint point) noexcept
+        -> std::array<double, 3> {
+        const auto x =
+            handle.get_origin_x() + static_cast<double>(point.x) * handle.get_resolution();
+        const auto y =
+            handle.get_origin_y() + static_cast<double>(point.y) * handle.get_resolution();
+        return std::array<double, 3> { x, y, handle.get_plane_z() };
+    }
+
+}
+
+PngEditMode::PngEditMode(Renderer& renderer, AssetsManager& assets) noexcept
+    : renderer { renderer }
+    , assets { assets } {
+    register_tool_handler(PngEditTool::Free,
+        ToolHandler {
+            .on_move = [](auto& self, Mouse& mouse, MouseEvent const&, EditContext& context) {
+                context.session.last_drag_point.reset();
+                self.clear_preview(context.handle, context.session);
+                if (!context.pixel.has_value()) {
+                    return;
+                }
+
+                const auto world = from_pixel(context.handle, *context.pixel);
+                mouse.set_status(mode_status(mouse, QString("坐标 %1").arg(format_xyz(world.data()))));
+            },
+            .on_lclick = [](auto& self, Mouse& mouse, MouseEvent const&, EditContext& context) {
+                self.clear_preview(context.handle, context.session);
+                if (!context.pixel.has_value()) {
+                    mouse.set_status(mode_status(mouse, "未命中平面"));
+                    return;
+                }
+
+                const auto world = from_pixel(context.handle, *context.pixel);
+                mouse.set_status(mode_status(mouse, QString("坐标 %1").arg(format_xyz(world.data()))));
+            },
+        });
+    register_tool_handler(PngEditTool::Point,
+        ToolHandler {
+            .on_move = [](auto& self, Mouse& mouse, MouseEvent const& event, EditContext& context) {
+                self.clear_preview(context.handle, context.session);
+                if (!context.pixel.has_value()) {
+                    context.session.last_drag_point.reset();
+                    return;
+                }
+                if ((event.buttons & Qt::LeftButton) == 0) {
+                    context.session.last_drag_point.reset();
+                    return;
+                }
+
+                const auto from = context.session.last_drag_point.value_or(*context.pixel);
+                if (!self.apply_stroke(mouse, context.handle, context.session,
+                        event::PngMapEditOperation::Draw, from, *context.pixel,
+                        mouse.png_edit_point_size(), "连续绘制")) {
+                    return;
+                }
+
+                context.session.last_drag_point = *context.pixel;
+            },
+            .on_lclick = [](auto& self, Mouse& mouse, MouseEvent const&, EditContext& context) {
+                if (!context.pixel.has_value()) {
+                    mouse.set_status(mode_status(mouse, "未命中平面"));
+                    return;
+                }
+                context.session.last_drag_point.reset();
+                self.clear_preview(context.handle, context.session);
+                self.apply_stroke(mouse, context.handle, context.session,
+                    event::PngMapEditOperation::Draw, *context.pixel, *context.pixel,
+                    mouse.png_edit_point_size(), "绘制点");
+            },
+        });
+    register_tool_handler(PngEditTool::Erase,
+        ToolHandler {
+            .on_move = [](auto& self, Mouse& mouse, MouseEvent const& event, EditContext& context) {
+                self.clear_preview(context.handle, context.session);
+                if (!context.pixel.has_value()) {
+                    context.session.last_drag_point.reset();
+                    return;
+                }
+                if ((event.buttons & Qt::LeftButton) == 0) {
+                    context.session.last_drag_point.reset();
+                    return;
+                }
+
+                const auto from = context.session.last_drag_point.value_or(*context.pixel);
+                if (!self.apply_stroke(mouse, context.handle, context.session,
+                        event::PngMapEditOperation::Erase, from, *context.pixel,
+                        mouse.png_edit_erase_size(), "连续擦除")) {
+                    return;
+                }
+
+                context.session.last_drag_point = *context.pixel;
+            },
+            .on_lclick = [](auto& self, Mouse& mouse, MouseEvent const&, EditContext& context) {
+                if (!context.pixel.has_value()) {
+                    mouse.set_status(mode_status(mouse, "未命中平面"));
+                    return;
+                }
+                context.session.last_drag_point.reset();
+                self.clear_preview(context.handle, context.session);
+                self.apply_stroke(mouse, context.handle, context.session,
+                    event::PngMapEditOperation::Erase, *context.pixel, *context.pixel,
+                    mouse.png_edit_erase_size(), "擦除");
+            },
+        });
+    register_tool_handler(PngEditTool::Line,
+        ToolHandler {
+            .on_move = [](auto& self, Mouse& mouse, MouseEvent const&, EditContext& context) {
+                context.session.last_drag_point.reset();
+                if (!context.session.pending_line_start.has_value() || !context.pixel.has_value()) {
+                    self.clear_preview(context.handle, context.session);
+                    return;
+                }
+
+                if (!self.show_preview(context.handle, context.session, *context.pixel,
+                        mouse.png_edit_line_width())) {
+                    mouse.set_status(mode_status(mouse, "线段预览失败"));
+                    return;
+                }
+
+                const auto world = from_pixel(context.handle, *context.pixel);
+                mouse.set_status(
+                    mode_status(mouse, QString("预览终点 %1").arg(format_xyz(world.data()))));
+            },
+            .on_lclick = [](auto& self, Mouse& mouse, MouseEvent const&, EditContext& context) {
+                if (!context.pixel.has_value()) {
+                    mouse.set_status(mode_status(mouse, "未命中平面"));
+                    return;
+                }
+
+                context.session.last_drag_point.reset();
+                if (!context.session.pending_line_start.has_value()) {
+                    context.session.pending_line_start = *context.pixel;
+                    const auto world = from_pixel(context.handle, *context.pixel);
+                    mouse.set_status(
+                        mode_status(mouse, QString("线起点 %1").arg(format_xyz(world.data()))));
+                    return;
+                }
+
+                auto result = self.apply_edit(context.session, context.handle,
+                    event::PngMapEditOperation::Draw, *context.session.pending_line_start,
+                    *context.pixel, mouse.png_edit_line_width());
+                if (!result.has_value()) {
+                    mouse.set_status(mode_status(mouse, "应用线绘制失败"));
+                    return;
+                }
+
+                context.session.pixels = std::move(result.value());
+                context.session.pending_line_start.reset();
+                self.clear_preview(context.handle, context.session);
+                if (!self.commit_session(context.handle, context.session)) {
+                    mouse.set_status(mode_status(mouse, "应用线绘制失败"));
+                    return;
+                }
+
+                const auto world = from_pixel(context.handle, *context.pixel);
+                mouse.set_status(mode_status(
+                    mouse, QString("绘制线段至 %1").arg(format_xyz(world.data()))));
+            },
+            .on_rclick = [](auto& self, Mouse& mouse, MouseEvent const&, EditContext& context) {
+                context.session.last_drag_point.reset();
+                if (!context.session.pending_line_start.has_value()) {
+                    return;
+                }
+
+                context.session.pending_line_start.reset();
+                self.clear_preview(context.handle, context.session);
+                mouse.set_status(mode_status(mouse, "已取消线绘制"));
+            },
+        });
+}
+
+auto PngEditMode::id() const noexcept -> MouseModeId { return MouseModeId::PngEdit; }
+
+auto PngEditMode::supports_selection(std::optional<MouseSelection> const& selection) const noexcept
+    -> bool {
+    return selection.has_value() && selection->kind == pcs::AssetKind::PngMap;
+}
+
+auto PngEditMode::allows_camera_interaction(Mouse const& mouse) const noexcept -> bool {
+    return png_edit_tool_descriptor(mouse.png_edit_tool()).allows_camera_interaction;
+}
+
+auto PngEditMode::on_init(Mouse& mouse) noexcept -> void {
+    mouse.set_status(mode_status(mouse));
+
+    mouse.on_move([this, &mouse](MouseEvent const& event) { on_move(mouse, event); });
+    mouse.on_lclick([this, &mouse](MouseEvent const& event) { on_lclick(mouse, event); });
+    mouse.on_rclick([this, &mouse](MouseEvent const& event) { on_rclick(mouse, event); });
+}
+
+auto PngEditMode::on_exit(Mouse& mouse) noexcept -> void {
+    for (auto& [asset_id, session] : sessions) {
+        auto handle = assets.get_png_map_handle(asset_id);
+        if (handle.has_value() && handle.value() != nullptr) {
+            handle.value()->clear_preview();
+        }
+        session.preview_visible = false;
+    }
+
+    sessions.clear();
+
+    mouse.set_status("PNG 编辑: 关闭");
+}
+
+auto PngEditMode::on_move(Mouse& mouse, MouseEvent const& event) noexcept -> void {
+    auto context = resolve_edit_context(mouse, event);
+    if (!context.has_value()) {
+        return;
+    }
+
+    auto iter = tool_handlers.find(mouse.png_edit_tool());
+    if (iter == tool_handlers.end() || !iter->second.on_move) {
+        return;
+    }
+
+    iter->second.on_move(*this, mouse, event, *context);
+}
+
+auto PngEditMode::on_lclick(Mouse& mouse, MouseEvent const& event) noexcept -> void {
+    auto context = resolve_edit_context(mouse, event);
+    if (!context.has_value()) {
+        return;
+    }
+
+    auto iter = tool_handlers.find(mouse.png_edit_tool());
+    if (iter == tool_handlers.end() || !iter->second.on_lclick) {
+        return;
+    }
+
+    iter->second.on_lclick(*this, mouse, event, *context);
+}
+
+auto PngEditMode::on_rclick(Mouse& mouse, MouseEvent const& event) noexcept -> void {
+    auto context = resolve_edit_context(mouse, event);
+    if (!context.has_value()) {
+        return;
+    }
+
+    auto iter = tool_handlers.find(mouse.png_edit_tool());
+    if (iter == tool_handlers.end() || !iter->second.on_rclick) {
+        return;
+    }
+
+    iter->second.on_rclick(*this, mouse, event, *context);
+}
+
+auto PngEditMode::register_tool_handler(PngEditTool tool, ToolHandler handler) noexcept -> void {
+    tool_handlers[tool] = std::move(handler);
+}
+
+auto PngEditMode::resolve_edit_context(Mouse& mouse, MouseEvent const& event) noexcept
+    -> std::optional<EditContext> {
+    const auto& selected = mouse.selected_asset();
+    if (!selected.has_value() || selected->kind != pcs::AssetKind::PngMap) {
+        return std::nullopt;
+    }
+
+    auto handle = assets.get_png_map_handle(selected->id);
+    if (!handle.has_value() || handle.value() == nullptr) {
+        mouse.set_status(mode_status(mouse, "PNG 地图不可用"));
+        return std::nullopt;
+    }
+
+    auto* session = ensure_session(selected->id, *handle.value());
+    if (session == nullptr) {
+        mouse.set_status(mode_status(mouse, "会话初始化失败"));
+        return std::nullopt;
+    }
+
+    return EditContext {
+        .asset_id = selected->id,
+        .handle   = *handle.value(),
+        .session  = *session,
+        .pixel    = pick_pixel(selected->id, event),
+    };
+}
+
+auto PngEditMode::pick_pixel(std::string const& asset_id, MouseEvent const& event) const noexcept
+    -> std::optional<PixelPoint> {
+    auto handle = assets.get_png_map_handle(asset_id);
+    if (!handle.has_value() || handle.value() == nullptr) {
+        return std::nullopt;
+    }
+
+    auto world = handle.value()->pick_plane_position(renderer, event.x, event.y);
+    if (!world.has_value()) {
+        return std::nullopt;
+    }
+
+    return to_pixel(*handle.value(), *world);
+}
+
+auto PngEditMode::ensure_session(std::string const& asset_id, PngMapHandle& handle) noexcept
+    -> Session* {
+    auto [iter, inserted]    = sessions.try_emplace(asset_id);
+    const auto expected_size = handle.get_width() * handle.get_height();
+    if (inserted || iter->second.pixels.size() != expected_size) {
+        iter->second.pixels = handle.copy_pixels();
+        iter->second.pending_line_start.reset();
+        iter->second.last_drag_point.reset();
+        iter->second.preview_visible = false;
+    }
+
+    return &iter->second;
+}
+
+auto PngEditMode::apply_edit(Session const& session, PngMapHandle& handle,
+    event::PngMapEditOperation operation, PixelPoint from, PixelPoint to,
+    std::size_t thickness) const noexcept -> event::ApplyPngMapEdit::Result {
+    auto context       = std::make_unique<event::ApplyPngMapEdit::Context>();
+    context->pixels    = session.pixels;
+    context->width     = handle.get_width();
+    context->height    = handle.get_height();
+    context->from      = from;
+    context->to        = to;
+    context->thickness = thickness;
+    context->operation = operation;
+    return event::ApplyPngMapEdit::runtime_exec(std::move(context));
+}
+
+auto PngEditMode::apply_stroke(Mouse& mouse, PngMapHandle& handle, Session& session,
+    event::PngMapEditOperation operation, PixelPoint from, PixelPoint to, std::size_t thickness,
+    QString const& verb) noexcept -> bool {
+    auto result = apply_edit(session, handle, operation, from, to, thickness);
+    if (!result.has_value()) {
+        mouse.set_status(mode_status(mouse, QString("%1失败").arg(verb)));
+        return false;
+    }
+
+    session.pixels = std::move(result.value());
+    if (!commit_session(handle, session)) {
+        mouse.set_status(mode_status(mouse, QString("%1失败").arg(verb)));
+        return false;
+    }
+
+    const auto world = from_pixel(handle, to);
+    mouse.set_status(mode_status(mouse, QString("%1 %2").arg(verb, format_xyz(world.data()))));
+    return true;
+}
+
+auto PngEditMode::show_preview(PngMapHandle& handle, Session& session, PixelPoint to,
+    std::size_t thickness) noexcept -> bool {
+    if (!session.pending_line_start.has_value()) {
+        return clear_preview(handle, session);
+    }
+
+    auto result = apply_edit(session, handle, event::PngMapEditOperation::Draw,
+        *session.pending_line_start, to, thickness);
+    if (!result.has_value()) {
+        return false;
+    }
+
+    session.preview_visible = handle.preview_pixels(result.value());
+    if (session.preview_visible) {
+        assets.update_renderer();
+    }
+    return session.preview_visible;
+}
+
+auto PngEditMode::clear_preview(PngMapHandle& handle, Session& session) noexcept -> bool {
+    if (!session.preview_visible) {
+        return true;
+    }
+
+    session.preview_visible = false;
+    const auto ok           = handle.clear_preview();
+    if (ok) {
+        assets.update_renderer();
+    }
+    return ok;
+}
+
+auto PngEditMode::commit_session(PngMapHandle& handle, Session const& session) noexcept -> bool {
+    if (session.pixels.empty()) {
+        return false;
+    }
+
+    if (!handle.overwrite_pixels(session.pixels)) {
+        return false;
+    }
+
+    assets.update_renderer();
+    return true;
+}
+
+}

--- a/src/gui/interaction/png-edit-mode.hh
+++ b/src/gui/interaction/png-edit-mode.hh
@@ -1,0 +1,71 @@
+#pragma once
+
+#include "core/assets.hh"
+#include "core/events/process/png-map-edit.hh"
+#include "core/map/png-edit-ops.hh"
+#include "core/renderer.hh"
+#include "gui/interaction/mouse.hh"
+
+#include <optional>
+#include <string>
+#include <functional>
+#include <unordered_map>
+#include <vector>
+
+namespace pcs::gui::interaction {
+
+class PngEditMode final : public MouseMode {
+public:
+    PngEditMode(Renderer&, AssetsManager&) noexcept;
+
+    auto id() const noexcept -> MouseModeId override;
+    auto on_init(Mouse&) noexcept -> void override;
+    auto on_exit(Mouse&) noexcept -> void override;
+    auto supports_selection(std::optional<MouseSelection> const&) const noexcept -> bool override;
+    auto allows_camera_interaction(Mouse const&) const noexcept -> bool override;
+
+private:
+    struct Session {
+        std::vector<std::uint8_t> pixels;
+        std::optional<PixelPoint> pending_line_start;
+        std::optional<PixelPoint> last_drag_point;
+        bool preview_visible = false;
+    };
+
+    struct EditContext {
+        std::string const& asset_id;
+        PngMapHandle& handle;
+        Session& session;
+        std::optional<PixelPoint> pixel;
+    };
+
+    struct ToolHandler {
+        std::function<void(PngEditMode&, Mouse&, MouseEvent const&, EditContext&)> on_move;
+        std::function<void(PngEditMode&, Mouse&, MouseEvent const&, EditContext&)> on_lclick;
+        std::function<void(PngEditMode&, Mouse&, MouseEvent const&, EditContext&)> on_rclick;
+    };
+
+    auto register_tool_handler(PngEditTool, ToolHandler) noexcept -> void;
+    auto resolve_edit_context(Mouse&, MouseEvent const&) noexcept -> std::optional<EditContext>;
+    auto on_move(Mouse&, MouseEvent const&) noexcept -> void;
+    auto on_lclick(Mouse&, MouseEvent const&) noexcept -> void;
+    auto on_rclick(Mouse&, MouseEvent const&) noexcept -> void;
+
+    auto pick_pixel(std::string const& asset_id, MouseEvent const&) const noexcept
+        -> std::optional<PixelPoint>;
+    auto ensure_session(std::string const& asset_id, PngMapHandle&) noexcept -> Session*;
+    auto apply_stroke(Mouse&, PngMapHandle&, Session&, event::PngMapEditOperation, PixelPoint from,
+        PixelPoint to, std::size_t thickness, QString const& verb) noexcept -> bool;
+    auto apply_edit(Session const&, PngMapHandle&, event::PngMapEditOperation, PixelPoint from,
+        PixelPoint to, std::size_t thickness) const noexcept -> event::ApplyPngMapEdit::Result;
+    auto show_preview(PngMapHandle&, Session&, PixelPoint to, std::size_t thickness) noexcept -> bool;
+    auto clear_preview(PngMapHandle&, Session&) noexcept -> bool;
+    auto commit_session(PngMapHandle&, Session const&) noexcept -> bool;
+
+    Renderer& renderer;
+    AssetsManager& assets;
+    std::unordered_map<std::string, Session> sessions;
+    std::unordered_map<PngEditTool, ToolHandler> tool_handlers;
+};
+
+}

--- a/src/gui/interaction/png-edit-tools.cc
+++ b/src/gui/interaction/png-edit-tools.cc
@@ -1,0 +1,28 @@
+#include "gui/interaction/png-edit-tools.hh"
+
+#include <array>
+
+namespace pcs::gui::interaction {
+
+auto default_png_edit_tool_descriptors() noexcept -> std::vector<PngEditToolDescriptor> const& {
+    static const auto descriptors = std::vector<PngEditToolDescriptor> {
+        { PngEditTool::Free, "自由", "mouse", 0, true },
+        { PngEditTool::Line, "线", "timeline", 1, false },
+        { PngEditTool::Point, "点", "fiber_manual_record", 2, false },
+        { PngEditTool::Erase, "擦除", "delete", 3, false },
+    };
+
+    return descriptors;
+}
+
+auto png_edit_tool_descriptor(PngEditTool tool) noexcept -> PngEditToolDescriptor const& {
+    for (auto const& descriptor : default_png_edit_tool_descriptors()) {
+        if (descriptor.id == tool) {
+            return descriptor;
+        }
+    }
+
+    return default_png_edit_tool_descriptors().front();
+}
+
+}

--- a/src/gui/interaction/png-edit-tools.hh
+++ b/src/gui/interaction/png-edit-tools.hh
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "gui/interaction/mouse.hh"
+
+#include <vector>
+
+#include <QString>
+
+namespace pcs::gui::interaction {
+
+struct PngEditToolDescriptor {
+    PngEditTool id;
+    QString label;
+    QString icon;
+    int param_index = 0;
+    bool allows_camera_interaction = false;
+};
+
+auto default_png_edit_tool_descriptors() noexcept -> std::vector<PngEditToolDescriptor> const&;
+auto png_edit_tool_descriptor(PngEditTool tool) noexcept -> PngEditToolDescriptor const&;
+
+}

--- a/src/gui/navigation.cc
+++ b/src/gui/navigation.cc
@@ -8,6 +8,8 @@
 #include <creeper-qt/widget/cards/outlined-card.hh>
 #include <creeper-qt/widget/image.hh>
 
+#include <qpointer.h>
+
 using namespace creeper;
 
 auto NavigationComponent(NavigationState& state) noexcept -> QPointer<QWidget> {
@@ -23,6 +25,42 @@ auto NavigationComponent(NavigationState& state) noexcept -> QPointer<QWidget> {
         ib::FixedSize { IconButton::kSmallContainerSize },
         ib::Font { state.icon_font.c_str(), IconButton::kSmallFontIconSize },
     };
+
+    const auto picker_enabled = [&state] {
+        if (state.picker_mode_getter) {
+            return state.picker_mode_getter();
+        }
+        return false;
+    };
+
+    const auto picker_button_type =
+        picker_enabled() ? ib::TypesToggleSelected : ib::TypesToggleUnselected;
+
+    auto picker_button = new IconButton {
+        common_button,
+        picker_button_type,
+        ib::ColorFilled,
+        ib::FontIcon { "ads_click" },
+        ib::ToolTip { "切换坐标拾取模式" },
+        ib::Clickable { [&](IconButton& self) {
+            if (!state.picker_mode_getter || !state.picker_mode_setter) {
+                return;
+            }
+
+            const auto next = !state.picker_mode_getter();
+            state.picker_mode_setter(next);
+            self.set_selected(next);
+        } },
+    };
+
+    if (state.mouse != nullptr) {
+        state.mouse->set_mode_sink([guard = QPointer<IconButton> { picker_button }](
+                                       ::pcs::gui::interaction::MouseModeId mode) {
+            if (guard != nullptr) {
+                guard->set_selected(mode == ::pcs::gui::interaction::MouseModeId::Picker);
+            }
+        });
+    }
 
     const auto AvatarComponent = new Image {
         im::FixedSize { 60, 60 },
@@ -71,6 +109,7 @@ auto NavigationComponent(NavigationState& state) noexcept -> QPointer<QWidget> {
                     },
                 },
             },
+            col::pro::Item { { 0, Qt::AlignHCenter }, picker_button },
 
             col::pro::Stretch { 255 },
 

--- a/src/gui/navigation.hh
+++ b/src/gui/navigation.hh
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "gui/interaction/mouse.hh"
+
 #include <creeper-qt/utility/theme/theme.hh>
 
 #include <qpointer.h>
@@ -9,6 +11,7 @@ struct NavigationState {
     creeper::ThemeManager& manager;
 
     std::string icon_font;
+    pcs::gui::interaction::Mouse* mouse = nullptr;
 
     struct ButtonContext {
         std::string_view name;
@@ -16,6 +19,9 @@ struct NavigationState {
         std::function<void()> callback;
     };
     std::vector<ButtonContext> buttons_context;
+
+    std::function<void(bool)> picker_mode_setter;
+    std::function<bool()> picker_mode_getter;
 
     std::function<void()> function_quit;
 };

--- a/src/gui/visualization-window.cc
+++ b/src/gui/visualization-window.cc
@@ -4,6 +4,18 @@
 #include <creeper-qt/layout/linear.hh>
 #include <creeper-qt/widget/cards/filled-card.hh>
 
+#include <QFont>
+#include <QFontMetrics>
+#include <QLabel>
+#include <QMouseEvent>
+#include <QPainterPath>
+#include <QRegion>
+
+#include <vtkRenderWindow.h>
+#include <vtkRenderWindowInteractor.h>
+
+#include <algorithm>
+
 using namespace creeper;
 
 template <class T>
@@ -13,7 +25,7 @@ struct Rounded : public T {
     auto resizeEvent(QResizeEvent* event) -> void override {
         T::resizeEvent(event);
 
-        auto path = QPainterPath {};
+        auto path = QPainterPath { };
         path.addRoundedRect(this->rect(), rounded_radius, rounded_radius);
 
         auto mask = QRegion(path.toFillPolygon().toPolygon());
@@ -23,12 +35,181 @@ struct Rounded : public T {
     double rounded_radius = 10;
 };
 
-auto VisualizationWindowComponent(VisualizationWindowState& state) noexcept -> QPointer<QWidget> {
+class InteractiveVtkWindow : public Rounded<pcs::QtVtkWindow> {
+public:
+    explicit InteractiveVtkWindow(pcs::gui::interaction::Mouse* mouse) noexcept
+        : mouse { mouse } {
+        setMouseTracking(true);
 
+        status_label = new QLabel { this };
+        status_label->setAttribute(Qt::WA_TransparentForMouseEvents, true);
+        status_label->setStyleSheet("QLabel {"
+                                    "color: white;"
+                                    "background: rgba(0, 0, 0, 160);"
+                                    "padding: 6px 8px;"
+                                    "border-radius: 8px;"
+                                    "}");
+
+        auto font = QFont { "WenQuanYi Micro Hei", 10 };
+        font.setStyleHint(QFont::SansSerif);
+        status_label->setFont(font);
+        status_label->show();
+    }
+
+    auto set_status_text(QString text) noexcept -> void {
+        status_text = std::move(text);
+        update_status_label();
+    }
+
+    auto sync_interaction_state() noexcept -> void {
+        auto* interactor = renderWindow() != nullptr ? renderWindow()->GetInteractor() : nullptr;
+        if (interactor == nullptr) {
+            return;
+        }
+
+        if (allow_camera_interaction()) {
+            interactor->Enable();
+            return;
+        }
+
+        interactor->Disable();
+    }
+
+protected:
+    auto resizeEvent(QResizeEvent* event) -> void override {
+        Rounded<pcs::QtVtkWindow>::resizeEvent(event);
+        update_status_label();
+    }
+
+    auto mouseMoveEvent(QMouseEvent* event) -> void override {
+        emit_move(*event);
+        if (allow_camera_interaction()) {
+            Rounded<pcs::QtVtkWindow>::mouseMoveEvent(event);
+            return;
+        }
+
+        event->accept();
+    }
+
+    auto mousePressEvent(QMouseEvent* event) -> void override {
+        emit_click(*event);
+        if (allow_camera_interaction()) {
+            Rounded<pcs::QtVtkWindow>::mousePressEvent(event);
+            return;
+        }
+
+        event->accept();
+    }
+
+    auto mouseReleaseEvent(QMouseEvent* event) -> void override {
+        if (allow_camera_interaction()) {
+            Rounded<pcs::QtVtkWindow>::mouseReleaseEvent(event);
+            return;
+        }
+
+        event->accept();
+    }
+
+private:
+    auto allow_camera_interaction() const noexcept -> bool {
+        if (mouse == nullptr) {
+            return true;
+        }
+        return mouse->allows_camera_interaction();
+    }
+
+    auto update_status_label() noexcept -> void {
+        if (status_label == nullptr) {
+            return;
+        }
+
+        if (status_text.isEmpty()) {
+            status_label->hide();
+            return;
+        }
+
+        status_label->show();
+
+        constexpr auto kMargin      = 12;
+        constexpr auto kPaddingLeft = 16;
+
+        const auto max_text_width = std::max(120, width() - kMargin * 2 - kPaddingLeft);
+        auto metrics              = QFontMetrics { status_label->font() };
+        auto text                 = metrics.elidedText(status_text, Qt::ElideRight, max_text_width);
+        status_label->setText(text);
+        status_label->adjustSize();
+
+        const auto h = status_label->height();
+        status_label->move(kMargin, std::max(0, height() - kMargin - h));
+    }
+
+    auto emit_move(QMouseEvent const& event) noexcept -> void {
+        if (mouse == nullptr) {
+            return;
+        }
+
+        mouse->emit_move(pcs::gui::interaction::MouseEvent {
+            .x         = event.position().toPoint().x(),
+            .y         = event.position().toPoint().y(),
+            .modifiers = event.modifiers(),
+            .buttons   = event.buttons(),
+        });
+    }
+
+    auto emit_click(QMouseEvent const& event) noexcept -> void {
+        if (mouse == nullptr) {
+            return;
+        }
+
+        const auto payload = pcs::gui::interaction::MouseEvent {
+            .x         = event.position().toPoint().x(),
+            .y         = event.position().toPoint().y(),
+            .modifiers = event.modifiers(),
+            .buttons   = event.buttons(),
+        };
+
+        if (event.button() == Qt::LeftButton) {
+            mouse->emit_lclick(payload);
+            return;
+        }
+        if (event.button() == Qt::RightButton) {
+            mouse->emit_rclick(payload);
+            return;
+        }
+    }
+
+    pcs::gui::interaction::Mouse* mouse = nullptr;
+    QLabel* status_label                = nullptr;
+    QString status_text;
+};
+
+auto VisualizationWindowComponent(VisualizationWindowState& state) noexcept -> QPointer<QWidget> {
     const auto QtVtkWindowComponent = [&] {
-        auto window = new Rounded<pcs::QtVtkWindow> {};
+        auto window = new InteractiveVtkWindow { state.mouse };
 
         state.renderer.connect_ui(*window);
+        window->sync_interaction_state();
+
+        if (state.mouse != nullptr) {
+            state.mouse->set_status_sink(
+                [guard = QPointer<InteractiveVtkWindow> { window }](QString const& text) {
+                    if (guard != nullptr) {
+                        guard->set_status_text(text);
+                    }
+                });
+            state.mouse->set_mode_sink(
+                [guard = QPointer<InteractiveVtkWindow> { window }](auto) {
+                    if (guard != nullptr) {
+                        guard->sync_interaction_state();
+                    }
+                });
+            state.mouse->set_png_edit_tool_sink(
+                [guard = QPointer<InteractiveVtkWindow> { window }](auto) {
+                    if (guard != nullptr) {
+                        guard->sync_interaction_state();
+                    }
+                });
+        }
 
         return window;
     };

--- a/src/gui/visualization-window.hh
+++ b/src/gui/visualization-window.hh
@@ -1,5 +1,6 @@
 #pragma once
 #include "core/renderer.hh"
+#include "gui/interaction/mouse.hh"
 
 #include <creeper-qt/utility/theme/theme.hh>
 
@@ -9,6 +10,7 @@
 struct VisualizationWindowState {
     creeper::ThemeManager& manager;
     pcs::Renderer& renderer;
+    pcs::gui::interaction::Mouse* mouse = nullptr;
 };
 
 auto VisualizationWindowComponent(VisualizationWindowState&) noexcept -> QPointer<QWidget>;

--- a/src/gui/working-panel.cc
+++ b/src/gui/working-panel.cc
@@ -35,28 +35,15 @@ constexpr auto kPanelWidthScale = 1.3;
 constexpr auto kPanelMinWidth   = 416;
 constexpr auto kPanelMaxWidth   = 728;
 
-static auto open_asset_location() noexcept -> std::expected<std::string, std::string_view> {
-    const auto location = QFileDialog::getOpenFileName(
-        nullptr, "打开资产", "", "资产文件 (*.pcd *.obj);;点云文件 (*.pcd);;模型文件 (*.obj)");
+static auto open_asset_location(QString const& filter) noexcept
+    -> std::expected<std::string, std::string_view> {
+    const auto location = QFileDialog::getOpenFileName(nullptr, "打开资产", "", filter);
 
     if (location.isEmpty()) {
         return std::unexpected { "用户取消了文件选择" };
     }
 
     return location.toStdString();
-}
-
-auto asset_kind_text(pcs::AssetKind kind) noexcept -> QString {
-    switch (kind) {
-    case pcs::AssetKind::Pointcloud:
-        return "点云";
-    case pcs::AssetKind::Model:
-        return "模型";
-    case pcs::AssetKind::PngMap:
-        return "PNG 地图";
-    }
-
-    return "未知";
 }
 
 auto fold_text_for_panel(QString const& value, int wrap_after = 36) noexcept -> QString {
@@ -91,44 +78,16 @@ auto fold_text_for_panel(QString const& value, int wrap_after = 36) noexcept -> 
     return folded;
 }
 
-auto trim_decimal_zeros(QString text) noexcept -> QString {
-    while (text.contains('.') && text.endsWith('0')) {
-        text.chop(1);
-    }
-    if (text.endsWith('.')) {
-        text.chop(1);
-    }
-    if (text == "-0") {
-        return "0";
-    }
-    return text;
-}
-
-auto format_size_mb(std::uintmax_t bytes) noexcept -> QString {
-    const auto mb = static_cast<double>(bytes) / (1024.0 * 1024.0);
-    return trim_decimal_zeros(QString::number(mb, 'f', 2));
-}
-
-auto asset_size_mb_text(std::string const& path, std::uintmax_t fallback_bytes) noexcept
-    -> QString {
-    if (!path.empty() && path != "<memory>") {
-        auto error      = std::error_code { };
-        const auto size = std::filesystem::file_size(path, error);
-        if (!error) {
-            return format_size_mb(size);
-        }
-    }
-
-    return format_size_mb(fallback_bytes);
-}
-
 }
 
 auto WorkingPanelComponent(WorkingPanelState& state) noexcept -> QPointer<QWidget> {
     auto& manager = state.manager;
     auto& assets  = state.assets;
+    auto* mouse   = state.mouse;
 
     auto current_asset_id = std::make_shared<std::string>();
+    auto* open_control    = state.open_control;
+    auto* asset_details_registry = state.asset_details_registry;
 
     auto location_list = new QStringListModel { };
 
@@ -170,14 +129,16 @@ auto WorkingPanelComponent(WorkingPanelState& state) noexcept -> QPointer<QWidge
         }
     };
 
-    action_host = new pcs::gui::working::ActionPanelHost(
-        pcs::gui::working::ActionPanelContext {
-            .manager             = &manager,
-            .assets              = &assets,
-            .refresh_assets_list = refresh_assets_list,
-            .select_asset        = select_asset,
-        },
-        font);
+    auto panel_context                = pcs::gui::working::ActionPanelContext { };
+    panel_context.manager             = &manager;
+    panel_context.assets              = &assets;
+    panel_context.runtime             = &state.runtime;
+    panel_context.mouse               = mouse;
+    panel_context.refresh_assets_list = refresh_assets_list;
+    panel_context.select_asset        = select_asset;
+
+    action_host =
+        new pcs::gui::working::ActionPanelHost(panel_context, state.action_panel_registry, font);
 
     const auto prop_row = [&](auto name, auto& prop) {
         return new Row {
@@ -189,7 +150,7 @@ auto WorkingPanelComponent(WorkingPanelState& state) noexcept -> QPointer<QWidge
                 text::pro::Text { name },
                 text::pro::Font { font },
                 text::pro::Alignment { Qt::AlignTop | Qt::AlignLeft },
-                widget::pro::FixedWidth { 54 },
+                widget::pro::FixedWidth { 82 },
             },
             row::pro::Item<Text> {
                 { 1, Qt::AlignTop },
@@ -252,13 +213,9 @@ auto WorkingPanelComponent(WorkingPanelState& state) noexcept -> QPointer<QWidge
         return new Row {
             row::pro::Spacing { 10 },
             row::pro::Margin { 5 },
-            row::pro::Item<Text> {
-                theme_manager,
-                text::pro::Text { "操作:" },
-                text::pro::Font { font },
-            },
             row::pro::Item { visibility_button->data() },
             row::pro::Item { delete_button->data() },
+            row::pro::Stretch { 255 },
         };
     };
 
@@ -302,9 +259,12 @@ auto WorkingPanelComponent(WorkingPanelState& state) noexcept -> QPointer<QWidge
             return;
         }
 
+        if (mouse != nullptr) {
+            mouse->set_selected_asset(id, *kind);
+        }
+
         *current_asset_id = id;
         *asset_name       = QString::fromStdString(assets.get_asset_name(id).value_or("未知"));
-        *asset_type       = asset_kind_text(*kind);
         *asset_path       = QString::fromStdString(assets.get_asset_path(id).value_or("未知"));
 
         const auto visible = assets.is_asset_visible(id).value_or(true);
@@ -320,53 +280,18 @@ auto WorkingPanelComponent(WorkingPanelState& state) noexcept -> QPointer<QWidge
 
         action_host->bind_asset(*kind, id);
 
-        switch (*kind) {
-        case pcs::AssetKind::Pointcloud:
-            if (auto result = assets.get_pointcloud_handle(id)) {
-                auto* handle               = result.value();
-                const auto points_count    = static_cast<std::uintmax_t>(handle->get_points_size());
-                const auto path            = assets.get_asset_path(id).value_or(std::string { });
-                const auto estimated_bytes = points_count * 3U * sizeof(float);
-
-                *asset_size = asset_size_mb_text(path, estimated_bytes);
-
-                const auto is_memory = path == "<memory>";
-                *asset_info          = QString("点数: %1 点, 状态: %2")
-                                           .arg(static_cast<qulonglong>(points_count))
-                                           .arg(is_memory ? "内存中" : "已保存");
+        if (asset_details_registry != nullptr) {
+            if (auto details = asset_details_registry->provide(*kind, assets, id)) {
+                *asset_type = details->type;
+                *asset_size = details->size;
+                *asset_info = details->info;
+                return;
             }
-            break;
-        case pcs::AssetKind::Model:
-            if (auto result = assets.get_model_handle(id)) {
-                auto* handle        = result.value();
-                const auto vertices = static_cast<std::uintmax_t>(handle->get_points_size());
-                const auto faces    = static_cast<std::uintmax_t>(handle->get_polys_size());
-                const auto path     = assets.get_asset_path(id).value_or(std::string { });
-                const auto estimated_bytes =
-                    vertices * 3U * sizeof(float) + faces * 3U * sizeof(std::uint32_t);
-
-                *asset_size = asset_size_mb_text(path, estimated_bytes);
-                *asset_info = QString("顶点: %1 点, 面数: %2 面")
-                                  .arg(static_cast<qulonglong>(vertices))
-                                  .arg(static_cast<qulonglong>(faces));
-            }
-            break;
-        case pcs::AssetKind::PngMap:
-            if (auto result = assets.get_png_map_handle(id)) {
-                auto* handle      = result.value();
-                const auto width  = static_cast<std::uintmax_t>(handle->get_width());
-                const auto height = static_cast<std::uintmax_t>(handle->get_height());
-                const auto path   = assets.get_asset_path(id).value_or(std::string { });
-
-                *asset_size = asset_size_mb_text(path, width * height);
-                *asset_info = QString("尺寸: %1 x %2 像素, 分辨率: %3 米/像素, Z: %4")
-                                  .arg(static_cast<qulonglong>(width))
-                                  .arg(static_cast<qulonglong>(height))
-                                  .arg(handle->get_resolution(), 0, 'f', 3)
-                                  .arg(handle->get_plane_z(), 0, 'f', 3);
-            }
-            break;
         }
+
+        *asset_type = "未知";
+        *asset_size = "未知";
+        *asset_info = "未知";
     };
 
     *assets_view = new AssetsView {
@@ -383,6 +308,10 @@ auto WorkingPanelComponent(WorkingPanelState& state) noexcept -> QPointer<QWidge
         *asset_path       = "未知";
         *asset_size       = "未知";
         *asset_info       = "未知";
+
+        if (mouse != nullptr) {
+            mouse->clear_selected_asset();
+        }
 
         if (visibility_button != nullptr && *visibility_button != nullptr) {
             sync_visibility_button(false);
@@ -431,10 +360,20 @@ auto WorkingPanelComponent(WorkingPanelState& state) noexcept -> QPointer<QWidge
     });
 
     const auto open_location = [=, &assets] {
+        if (open_control == nullptr) {
+            QMessageBox::warning(nullptr, "打开失败", "未注册任何可打开的资产格式。");
+            return;
+        }
+
         const auto previous_last = last_asset_id();
 
-        if (auto result = open_asset_location()) {
-            assets.open_file(*result);
+        if (auto result = open_asset_location(open_control->dialog_filter())) {
+            if (auto open_result = open_control->open(*result); !open_result.has_value()) {
+                QMessageBox::warning(nullptr, "打开失败",
+                    QString::fromStdString(open_result.error()));
+                return;
+            }
+
             refresh_assets_list();
 
             const auto current_last = last_asset_id();
@@ -476,7 +415,9 @@ auto WorkingPanelComponent(WorkingPanelState& state) noexcept -> QPointer<QWidge
             widget::pro::Layout<Col> {
                 col::pro::Margin { 0 },
                 col::pro::Spacing { 5 },
+                col::pro::Alignment { Qt::AlignHCenter },
                 col::pro::Item<IconButton> {
+                    { 0, Qt::AlignHCenter },
                     icon_button::pro::ThemeManager { manager },
                     icon_button::pro::FixedSize { IconButton::kSmallContainerSize },
                     icon_button::pro::FontIcon { icon },
@@ -487,6 +428,7 @@ auto WorkingPanelComponent(WorkingPanelState& state) noexcept -> QPointer<QWidge
                     icon_button::pro::ShapeSquare,
                 },
                 col::pro::Item<Text> {
+                    { 0, Qt::AlignHCenter },
                     text::pro::ThemeManager { manager },
                     text::pro::Text { name },
                     text::pro::FixedWidth { 50 },

--- a/src/gui/working-panel.hh
+++ b/src/gui/working-panel.hh
@@ -1,5 +1,9 @@
 #pragma once
 #include "core/assets.hh"
+#include "core/runtime.hh"
+#include "gui/interaction/mouse.hh"
+#include "gui/working/asset-details.hh"
+#include "gui/working/open-control.hh"
 
 #include <creeper-qt/utility/theme/theme.hh>
 #include <creeper-qt/utility/wrapper/mutable-value.hh>
@@ -8,10 +12,19 @@
 #include <qpointer.h>
 #include <qwidget.h>
 
+namespace pcs::gui::working {
+class ActionPanelRegistry;
+}
+
 struct WorkingPanelState {
     creeper::ThemeManager& manager;
     pcs::AssetsManager& assets;
+    pcs::Runtime& runtime;
     pcs::Renderer& renderer;
+    pcs::gui::working::OpenControl* open_control                  = nullptr;
+    pcs::gui::working::AssetDetailsRegistry* asset_details_registry = nullptr;
+    pcs::gui::interaction::Mouse* mouse                           = nullptr;
+    pcs::gui::working::ActionPanelRegistry* action_panel_registry = nullptr;
 
     creeper::MutableDouble panel_width { 300. };
 

--- a/src/gui/working/action-panels.cc
+++ b/src/gui/working/action-panels.cc
@@ -1,646 +1,41 @@
 #include "gui/working/action-panels.hh"
 
-#include "core/events/process/pointcloud-to-png-map.hh"
-
-#include <creeper-qt/layout/linear.hh>
-#include <creeper-qt/widget/sliders.hh>
 #include <creeper-qt/widget/text.hh>
 
-#include <QCoreApplication>
-#include <QMetaObject>
-#include <QPointer>
 #include <QSizePolicy>
-#include <QThreadPool>
-
-#include <qfiledialog.h>
-#include <qmessagebox.h>
-
-#include <spdlog/spdlog.h>
 
 #include <algorithm>
-#include <cmath>
-#include <cstdint>
-#include <expected>
-#include <filesystem>
-#include <memory>
-#include <string>
-#include <system_error>
-#include <tuple>
 
 namespace pcs::gui::working {
 
-namespace {
-
-    constexpr auto kLargePointcloudBytes = std::uintmax_t { 100 } * 1024U * 1024U;
-
-    namespace text_field_props {
-        using Token = text_field::pro::Token;
-
-        using Measurements = SetterProp<Token, text_field::internal::BasicTextField::Measurements,
-            [](auto& self, const auto& value) { self.set_measurements(value); }>;
-
-        using Text =
-            SetterProp<Token, QString, [](auto& self, const auto& value) { self.setText(value); }>;
-    }
-
-    auto save_pointcloud_location(std::string const& suggested_name) noexcept
-        -> std::expected<std::string, std::string_view> {
-        auto filename = std::filesystem::path(suggested_name);
-        if (filename.extension() != ".pcd") {
-            filename.replace_extension(".pcd");
-        }
-
-        const auto location = QFileDialog::getSaveFileName(
-            nullptr, "保存点云", QString::fromStdString(filename.string()), "点云文件 (*.pcd)");
-
-        if (location.isEmpty()) {
-            return std::unexpected { "用户取消保存点云" };
-        }
-
-        return location.toStdString();
-    }
-
-    auto save_png_map_location(std::string const& suggested_name) noexcept
-        -> std::expected<std::string, std::string_view> {
-        auto filename = std::filesystem::path(suggested_name);
-        if (filename.extension() != ".png") {
-            filename.replace_extension(".png");
-        }
-
-        const auto location = QFileDialog::getSaveFileName(nullptr, "保存 PNG 地图",
-            QString::fromStdString(filename.string()), "PNG 图片 (*.png)");
-
-        if (location.isEmpty()) {
-            return std::unexpected { "用户取消保存 PNG 地图" };
-        }
-
-        return location.toStdString();
-    }
-
-    auto parse_double_input(text_field::internal::BasicTextField* input, double fallback,
-        double minimum) noexcept -> double {
-        auto parsed = double { };
-        auto ok     = false;
-        parsed      = input->text().toDouble(&ok);
-
-        if (!ok || parsed < minimum) {
-            parsed = fallback;
-        }
-
-        auto normalized = QString::number(parsed, 'f', 6);
-        while (normalized.contains('.') && normalized.endsWith('0')) {
-            normalized.chop(1);
-        }
-        if (normalized.endsWith('.')) {
-            normalized.chop(1);
-        }
-        if (normalized == "-0") {
-            normalized = "0";
-        }
-
-        input->setText(normalized);
-        return parsed;
-    }
-
-    auto parse_size_input(text_field::internal::BasicTextField* input, std::size_t fallback,
-        std::size_t minimum) noexcept -> std::size_t {
-        auto ok     = false;
-        auto parsed = input->text().toULongLong(&ok);
-
-        if (!ok || parsed < minimum) {
-            parsed = fallback;
-        }
-
-        input->setText(QString::number(parsed));
-        return static_cast<std::size_t>(parsed);
-    }
-
-    auto compact_text_field_measurements() noexcept
-        -> text_field::internal::BasicTextField::Measurements {
-        auto measurement                 = text_field::internal::BasicTextField::Measurements { };
-        measurement.container_height     = 34;
-        measurement.icon_rect_size       = 16;
-        measurement.input_rect_size      = 16;
-        measurement.label_rect_size      = 12;
-        measurement.standard_font_height = 12;
-        measurement.col_padding          = 6;
-        measurement.row_padding_without_icons        = 10;
-        measurement.row_padding_with_icons           = 10;
-        measurement.row_padding_populated_label_text = 0;
-        return measurement;
-    }
-
-    auto make_parameter_field(theme::pro::ThemeManager const& theme, QFont const& font, int width,
-        text_field::internal::BasicTextField::Measurements const& measurements,
-        QString const& default_value) noexcept -> OutlinedTextField* {
-        return new OutlinedTextField {
-            theme,
-            widget::pro::Font { font },
-            widget::pro::FixedWidth { width },
-            text_field_props::Measurements { measurements },
-            text_field_props::Text { default_value },
-        };
-    }
-
-    auto confirm_large_pointcloud_warning(std::uintmax_t bytes) noexcept -> bool {
-        const auto size_mb = static_cast<double>(bytes) / (1024.0 * 1024.0);
-        const auto message = QString("当前点云大小为 %1 MB（超过 100 MB），生成 PNG "
-                                     "地图可能耗时较长，是否继续？")
-                                 .arg(size_mb, 0, 'f', 1);
-
-        const auto answer = QMessageBox::warning(nullptr, "大体积点云提示", message,
-            QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
-
-        return answer == QMessageBox::Yes;
-    }
-
+auto ActionPanelRegistry::register_factory(pcs::AssetKind kind, Factory factory) noexcept -> void {
+    factories[kind] = std::move(factory);
 }
 
-PointcloudActionPanel::PointcloudActionPanel(ActionPanelContext context, QFont const& font)
-    : context { std::move(context) } {
-    const auto theme = theme::pro::ThemeManager { *this->context.manager };
-
-    const auto update_color = [this] {
-        if (selected_asset_id.empty()) {
-            return;
-        }
-
-        if (auto result = this->context.assets->get_pointcloud_handle(selected_asset_id)) {
-            auto* handle = result.value();
-            handle->set_overall_color(
-                *color_channels[0], *color_channels[1], *color_channels[2], *color_channels[3]);
-            this->context.assets->update_renderer();
-        }
-    };
-
-    const auto make_slider = [=](std::shared_ptr<MutableDouble> channel, std::string_view name) {
-        auto measurement          = Slider::Measurements::Xs();
-        measurement.handle_height = 22;
-
-        return new Row {
-            row::pro::Spacing { 8 },
-            row::pro::Item<Text> {
-                theme,
-                MutableTransform {
-                    [name](Text& self, double value) {
-                        self.setText(QString("%1: %2")
-                                .arg(QString::fromStdString(std::string { name }))
-                                .arg(QString::number(value, 'f', 2)));
-                    },
-                    channel,
-                },
-                text::pro::Font { font },
-            },
-            row::pro::Item<Slider> {
-                { 255 },
-                theme,
-                slider::pro::Measurements { measurement },
-                MutableForward {
-                    slider::pro::Progress { 0 },
-                    channel,
-                },
-                slider::pro::FixedHeight { measurement.minimum_height() },
-                slider::pro::OnValueChangeFinished {
-                    [=](double v) {
-                        *channel = v;
-                        update_color();
-                    },
-                },
-            },
-        };
-    };
-
-    const auto measurements = compact_text_field_measurements();
-
-    const auto make_input_row = [=](std::string_view label,
-                                    text_field::internal::BasicTextField*& input,
-                                    QString const& default_value) {
-        auto* field = make_parameter_field(theme, font, 116, measurements, default_value);
-        input       = field;
-
-        return new Row {
-            row::pro::Spacing { 8 },
-            row::pro::Item<Text> {
-                { 0, Qt::AlignVCenter },
-                theme,
-                text::pro::Font { font },
-                text::pro::Text { QString::fromStdString(std::string { label }) },
-                text::pro::WordWrap { true },
-                text::pro::Alignment { Qt::AlignVCenter | Qt::AlignLeft },
-                widget::pro::FixedWidth { 92 },
-            },
-            row::pro::Item { { 1, Qt::AlignVCenter }, field },
-        };
-    };
-
-    const auto make_dual_input_row = [=](std::string_view label,
-                                         text_field::internal::BasicTextField*& first,
-                                         QString const& first_default,
-                                         text_field::internal::BasicTextField*& second,
-                                         QString const& second_default) {
-        auto* first_field = make_parameter_field(theme, font, 56, measurements, first_default);
-        first             = first_field;
-
-        auto* second_field = make_parameter_field(theme, font, 56, measurements, second_default);
-        second             = second_field;
-
-        return new Row {
-            row::pro::Spacing { 8 },
-            row::pro::Item<Text> {
-                { 0, Qt::AlignVCenter },
-                theme,
-                text::pro::Font { font },
-                text::pro::Text { QString::fromStdString(std::string { label }) },
-                text::pro::WordWrap { true },
-                text::pro::Alignment { Qt::AlignVCenter | Qt::AlignLeft },
-                widget::pro::FixedWidth { 92 },
-            },
-            row::pro::Item<Row> {
-                { 1, Qt::AlignVCenter },
-                row::pro::Spacing { 4 },
-                row::pro::Item { first_field },
-                row::pro::Item { second_field },
-            },
-        };
-    };
-
-    const auto set_generate_busy = [this](bool busy) {
-        if (generate_button == nullptr) {
-            return;
-        }
-
-        generate_button->setDisabled(busy);
-        generate_button->setText(busy ? QString::fromUtf8("生成中") : "生成 PNG 地图");
-    };
-
-    const auto should_continue_large_generation = [this](std::size_t points_count) -> bool {
-        const auto path = this->context.assets->get_asset_path(selected_asset_id).value_or("");
-        if (!path.empty() && path != "<memory>") {
-            auto error      = std::error_code { };
-            const auto size = std::filesystem::file_size(path, error);
-            if (!error && size > kLargePointcloudBytes) {
-                return confirm_large_pointcloud_warning(size);
-            }
-            return true;
-        }
-
-        constexpr auto bytes_per_point = sizeof(double) * 3U;
-        const auto estimated_size = static_cast<std::uintmax_t>(points_count) * bytes_per_point;
-        if (estimated_size > kLargePointcloudBytes) {
-            return confirm_large_pointcloud_warning(estimated_size);
-        }
-
-        return true;
-    };
-
-    save_button = new OutlinedButton {
-        theme,
-        widget::pro::FixedHeight { 36 },
-        widget::pro::MinimumWidth { 180 },
-        button::pro::Text { "保存点云" },
-    };
-
-    generate_button = new OutlinedButton {
-        theme,
-        widget::pro::FixedHeight { 36 },
-        widget::pro::MinimumWidth { 180 },
-        button::pro::Text { "生成 PNG 地图" },
-    };
-
-    QObject::connect(save_button, &OutlinedButton::clicked, [this](bool) {
-        if (selected_asset_id.empty()) {
-            return;
-        }
-
-        const auto suggested =
-            this->context.assets->get_asset_name(selected_asset_id).value_or("pointcloud.pcd");
-        if (auto location = save_pointcloud_location(suggested)) {
-            const auto result =
-                this->context.assets->save_pointcloud_asset(selected_asset_id, *location);
-            if (!result.has_value()) {
-                spdlog::error("保存点云资产失败: {}", result.error());
-                return;
-            }
-
-            this->context.refresh_assets_list();
-            this->context.select_asset(selected_asset_id);
-        }
-    });
-
-    QObject::connect(generate_button, &OutlinedButton::clicked,
-        [this, set_generate_busy, should_continue_large_generation](bool) {
-            if (selected_asset_id.empty()) {
-                return;
-            }
-            if (generate_button != nullptr && !generate_button->isEnabled()) {
-                return;
-            }
-
-            const auto handle_result =
-                this->context.assets->get_pointcloud_handle(selected_asset_id);
-            if (!handle_result.has_value()) {
-                spdlog::error("点云句柄不可用");
-                return;
-            }
-
-            auto source_points = handle_result.value()->get_positions();
-            if (source_points.empty()) {
-                spdlog::error("点云为空");
-                return;
-            }
-
-            if (!should_continue_large_generation(source_points.size())) {
-                return;
-            }
-
-            auto params             = pcs::PngMapParameters { };
-            params.resolution       = parse_double_input(resolution_input, 0.1, 0.01);
-            params.points_limit     = parse_size_input(points_limit_input, 5, 1);
-            params.height_limit     = parse_double_input(height_limit_input, 0.1, 0.0);
-            params.influence_radius = parse_double_input(influence_radius_input, 0.08, 0.0);
-            params.z_area_start     = parse_double_input(z_area_start_input, 0.0, 0.0);
-            params.z_area_end       = parse_double_input(z_area_end_input, 0.2, 0.0);
-
-            set_generate_busy(true);
-
-            auto context_copy    = this->context;
-            auto source_asset_id = std::string { selected_asset_id };
-            auto button_guard    = QPointer<OutlinedButton> { generate_button };
-            auto panel_guard     = QPointer<QWidget> { root };
-
-            QThreadPool::globalInstance()->start([context_copy,
-                                                     source_asset_id = std::move(source_asset_id),
-                                                     source_points   = std::move(source_points),
-                                                     params, button_guard, panel_guard]() mutable {
-                auto event_context =
-                    std::make_unique<pcs::event::ConvertPointcloudToPngMap::Context>();
-                event_context->points     = std::move(source_points);
-                event_context->parameters = params;
-
-                auto compute_result =
-                    std::make_shared<pcs::event::ConvertPointcloudToPngMap::Result>(
-                        pcs::event::ConvertPointcloudToPngMap::runtime_exec(
-                            std::move(event_context)));
-
-                QMetaObject::invokeMethod(
-                    QCoreApplication::instance(),
-                    [context_copy, source_asset_id = std::move(source_asset_id), compute_result,
-                        button_guard, panel_guard]() {
-                        if (button_guard) {
-                            button_guard->setDisabled(false);
-                            button_guard->setText("生成 PNG 地图");
-                        }
-
-                        if (!panel_guard) {
-                            return;
-                        }
-
-                        if (!compute_result->has_value()) {
-                            spdlog::error("点云生成 PNG 地图失败: {}", compute_result->error());
-                            return;
-                        }
-
-                        const auto create_result = context_copy.assets->upsert_generated_png_map(
-                            source_asset_id, compute_result->value());
-                        if (!create_result.has_value()) {
-                            spdlog::error("创建 PNG 地图资产失败: {}", create_result.error());
-                            return;
-                        }
-
-                        context_copy.refresh_assets_list();
-                        context_copy.select_asset(*create_result);
-                    },
-                    Qt::QueuedConnection);
-            });
-        });
-
-    root = new FilledCard {
-        theme,
-        card::pro::LevelLow,
-        card::pro::Layout<Col> {
-            col::pro::Alignment { Qt::AlignTop },
-            col::pro::Margin { 10 },
-            col::pro::Spacing { 10 },
-            col::pro::Item<Text> {
-                theme,
-                text::pro::Font { font },
-                text::pro::Text { "点云操作" },
-                text::pro::Alignment { Qt::AlignHCenter },
-            },
-            col::pro::Item<FilledCard> {
-                theme,
-                card::pro::LevelLowest,
-                card::pro::Layout<Col> {
-                    col::pro::Margin { 8 },
-                    col::pro::Spacing { 4 },
-                    col::pro::Item { make_slider(color_channels[0], "R") },
-                    col::pro::Item { make_slider(color_channels[1], "G") },
-                    col::pro::Item { make_slider(color_channels[2], "B") },
-                    col::pro::Item { make_slider(color_channels[3], "A") },
-                },
-            },
-            col::pro::Item<FilledCard> {
-                theme,
-                card::pro::LevelLowest,
-                card::pro::Layout<Col> {
-                    col::pro::Margin { 8 },
-                    col::pro::Spacing { 4 },
-                    col::pro::Item { make_input_row("分辨率（m）", resolution_input, "0.1") },
-                    col::pro::Item { make_input_row("有效点云数（点）", points_limit_input, "5") },
-                    col::pro::Item { make_input_row("有效高度差（m）", height_limit_input, "0.1") },
-                    col::pro::Item {
-                        make_input_row("影响半径（m）", influence_radius_input, "0.08") },
-                    col::pro::Item { make_dual_input_row(
-                        "Z 区间（m）", z_area_start_input, "0", z_area_end_input, "0.2") },
-                    col::pro::Item { generate_button },
-                },
-            },
-            col::pro::Item { save_button },
-        },
-    };
-}
-
-auto PointcloudActionPanel::widget() const noexcept -> QWidget* { return root; }
-
-auto PointcloudActionPanel::bind_asset(std::string const& id) noexcept -> void {
-    selected_asset_id = id;
-
-    if (auto result = context.assets->get_pointcloud_handle(selected_asset_id)) {
-        auto* handle = result.value();
-        std::tie(*color_channels[0], *color_channels[1], *color_channels[2], *color_channels[3]) =
-            handle->get_overall_color();
+auto ActionPanelRegistry::create(pcs::AssetKind kind, ActionPanelContext context,
+    QFont const& font) const noexcept -> std::unique_ptr<AssetActionPanel> {
+    auto iter = factories.find(kind);
+    if (iter == factories.end() || !iter->second) {
+        return nullptr;
     }
+
+    return iter->second(std::move(context), font);
 }
 
-auto PointcloudActionPanel::clear() noexcept -> void { selected_asset_id.clear(); }
-
-ModelActionPanel::ModelActionPanel(ActionPanelContext context, QFont const& font)
-    : context { std::move(context) } {
-    const auto theme        = theme::pro::ThemeManager { *this->context.manager };
-    const auto measurements = compact_text_field_measurements();
-
-    const auto make_input_row = [=](std::string_view label,
-                                    text_field::internal::BasicTextField*& input,
-                                    QString const& default_value) {
-        auto* field = make_parameter_field(theme, font, 116, measurements, default_value);
-        input       = field;
-
-        return new Row {
-            row::pro::Spacing { 8 },
-            row::pro::Item<Text> {
-                { 0, Qt::AlignVCenter },
-                theme,
-                text::pro::Font { font },
-                text::pro::Text { QString::fromStdString(std::string { label }) },
-                text::pro::WordWrap { true },
-                text::pro::Alignment { Qt::AlignVCenter | Qt::AlignLeft },
-                widget::pro::FixedWidth { 92 },
-            },
-            row::pro::Item { { 1, Qt::AlignVCenter }, field },
-        };
-    };
-
-    convert_button = new OutlinedButton {
-        theme,
-        widget::pro::FixedHeight { 36 },
-        widget::pro::MinimumWidth { 180 },
-        button::pro::Text { "转换为点云" },
-    };
-
-    QObject::connect(convert_button, &OutlinedButton::clicked, [this](bool) {
-        if (selected_asset_id.empty()) {
-            return;
-        }
-
-        auto parameters            = pcs::ModelToPointcloudParameters { };
-        parameters.density         = parse_double_input(density_input, 1.0, 0.01);
-        parameters.sample_distance = parse_double_input(sample_distance_input, 0.0, 0.0);
-        parameters.unit_scale      = parse_double_input(unit_scale_input, 1.0, 1e-6);
-        parameters.max_points      = parse_size_input(max_points_input, 0, 0);
-
-        const auto result =
-            this->context.assets->convert_model_to_pointcloud(selected_asset_id, parameters);
-        if (!result.has_value()) {
-            spdlog::error("模型转点云失败: {}", result.error());
-            return;
-        }
-
-        this->context.refresh_assets_list();
-        this->context.select_asset(*result);
-    });
-
-    root = new FilledCard {
-        theme,
-        card::pro::LevelLow,
-        card::pro::Layout<Col> {
-            col::pro::Alignment { Qt::AlignTop },
-            col::pro::Margin { 10 },
-            col::pro::Spacing { 10 },
-            col::pro::Item<Text> {
-                theme,
-                text::pro::Font { font },
-                text::pro::Text { "模型操作" },
-                text::pro::Alignment { Qt::AlignHCenter },
-            },
-            col::pro::Item<FilledCard> {
-                theme,
-                card::pro::LevelLowest,
-                card::pro::Layout<Col> {
-                    col::pro::Margin { 8 },
-                    col::pro::Spacing { 4 },
-                    col::pro::Item { make_input_row("点云密度（倍）", density_input, "1") },
-                    col::pro::Item { make_input_row("采样间距（m）", sample_distance_input, "0") },
-                    col::pro::Item { make_input_row("缩放比例（倍）", unit_scale_input, "1") },
-                    col::pro::Item { make_input_row("最大点数（点）", max_points_input, "0") },
-                },
-            },
-            col::pro::Item { convert_button },
-        },
-    };
-}
-
-auto ModelActionPanel::widget() const noexcept -> QWidget* { return root; }
-
-auto ModelActionPanel::bind_asset(std::string const& id) noexcept -> void {
-    selected_asset_id = id;
-}
-
-auto ModelActionPanel::clear() noexcept -> void { selected_asset_id.clear(); }
-
-PngMapActionPanel::PngMapActionPanel(ActionPanelContext context, QFont const& font)
-    : context { std::move(context) } {
-    const auto theme = theme::pro::ThemeManager { *this->context.manager };
-
-    save_button = new OutlinedButton {
-        theme,
-        widget::pro::FixedHeight { 36 },
-        widget::pro::MinimumWidth { 180 },
-        button::pro::Text { "保存 PNG 地图" },
-    };
-
-    QObject::connect(save_button, &OutlinedButton::clicked, [this](bool) {
-        if (selected_asset_id.empty()) {
-            return;
-        }
-
-        const auto suggested_name =
-            this->context.assets->get_asset_name(selected_asset_id).value_or("map.png");
-        if (auto location = save_png_map_location(suggested_name)) {
-            const auto result =
-                this->context.assets->save_png_map_asset(selected_asset_id, *location);
-            if (!result.has_value()) {
-                spdlog::error("保存 PNG 地图资产失败: {}", result.error());
-                return;
-            }
-
-            this->context.refresh_assets_list();
-            this->context.select_asset(selected_asset_id);
-        }
-    });
-
-    root = new FilledCard {
-        theme,
-        card::pro::LevelLow,
-        card::pro::Layout<Col> {
-            col::pro::Alignment { Qt::AlignTop },
-            col::pro::Margin { 10 },
-            col::pro::Spacing { 10 },
-            col::pro::Item<Text> {
-                theme,
-                text::pro::Font { font },
-                text::pro::Text { "PNG 地图操作" },
-                text::pro::Alignment { Qt::AlignHCenter },
-            },
-            col::pro::Item { save_button },
-        },
-    };
-}
-
-auto PngMapActionPanel::widget() const noexcept -> QWidget* { return root; }
-
-auto PngMapActionPanel::bind_asset(std::string const& id) noexcept -> void {
-    selected_asset_id = id;
-}
-
-auto PngMapActionPanel::clear() noexcept -> void { selected_asset_id.clear(); }
-
-ActionPanelHost::ActionPanelHost(ActionPanelContext context, QFont const& font) {
+ActionPanelHost::ActionPanelHost(
+    ActionPanelContext context, ActionPanelRegistry const* registry, QFont const& font)
+    : context { std::move(context) }
+    , registry { registry }
+    , font { font } {
     placeholder = new Text {
-        theme::pro::ThemeManager { *context.manager },
+        theme::pro::ThemeManager { *this->context.manager },
         text::pro::Text { "暂无专属操作" },
         text::pro::Alignment { Qt::AlignHCenter },
-        text::pro::Font { font },
+        text::pro::Font { this->font },
     };
-
-    pointcloud_panel = std::make_unique<PointcloudActionPanel>(context, font);
-    model_panel      = std::make_unique<ModelActionPanel>(context, font);
-    png_map_panel    = std::make_unique<PngMapActionPanel>(context, font);
 
     stack = new Stacked {
         stacked::pro::Item { placeholder },
-        stacked::pro::Item { pointcloud_panel->widget() },
-        stacked::pro::Item { model_panel->widget() },
-        stacked::pro::Item { png_map_panel->widget() },
         stacked::pro::CurrentIndex { kPlaceholderIndex },
     };
 
@@ -656,31 +51,53 @@ ActionPanelHost::ActionPanelHost(ActionPanelContext context, QFont const& font) 
 auto ActionPanelHost::widget() const noexcept -> QWidget* { return root; }
 
 auto ActionPanelHost::clear() noexcept -> void {
-    pointcloud_panel->clear();
-    model_panel->clear();
-    png_map_panel->clear();
+    for (auto& [_, panel] : panels) {
+        if (panel) {
+            panel->clear();
+        }
+    }
+
     stack->setCurrentIndex(kPlaceholderIndex);
     sync_current_panel_height();
 }
 
 auto ActionPanelHost::bind_asset(pcs::AssetKind kind, std::string const& id) noexcept -> void {
-    switch (kind) {
-    case pcs::AssetKind::Pointcloud:
-        pointcloud_panel->bind_asset(id);
-        stack->setCurrentIndex(kPointcloudIndex);
-        sync_current_panel_height();
-        return;
-    case pcs::AssetKind::Model:
-        model_panel->bind_asset(id);
-        stack->setCurrentIndex(kModelIndex);
-        sync_current_panel_height();
-        return;
-    case pcs::AssetKind::PngMap:
-        png_map_panel->bind_asset(id);
-        stack->setCurrentIndex(kPngMapIndex);
+    auto* panel = ensure_panel(kind);
+    if (panel == nullptr) {
+        stack->setCurrentIndex(kPlaceholderIndex);
         sync_current_panel_height();
         return;
     }
+
+    panel->bind_asset(id);
+    stack->setCurrentIndex(panel_indices[kind]);
+    sync_current_panel_height();
+}
+
+auto ActionPanelHost::ensure_panel(pcs::AssetKind kind) noexcept -> AssetActionPanel* {
+    if (auto iter = panels.find(kind); iter != panels.end() && iter->second != nullptr) {
+        return iter->second.get();
+    }
+
+    if (registry == nullptr) {
+        return nullptr;
+    }
+
+    auto panel = registry->create(kind, context, font);
+    if (panel == nullptr || panel->widget() == nullptr) {
+        return nullptr;
+    }
+
+    const auto index    = stack->addWidget(panel->widget());
+    panel_indices[kind] = index;
+
+    if (context.manager != nullptr) {
+        context.manager->apply_theme();
+    }
+
+    auto* raw    = panel.get();
+    panels[kind] = std::move(panel);
+    return raw;
 }
 
 auto ActionPanelHost::sync_current_panel_height() noexcept -> void {

--- a/src/gui/working/action-panels.hh
+++ b/src/gui/working/action-panels.hh
@@ -1,27 +1,27 @@
 #pragma once
 
 #include "core/assets.hh"
+#include "core/runtime.hh"
+#include "gui/interaction/mouse.hh"
 
 #include <creeper-qt/layout/stacked.hh>
 #include <creeper-qt/utility/theme/theme.hh>
-#include <creeper-qt/utility/wrapper/mutable-value.hh>
-#include <creeper-qt/widget/buttons/outlined-button.hh>
-#include <creeper-qt/widget/cards/filled-card.hh>
-#include <creeper-qt/widget/text-fields.hh>
 #include <creeper-qt/widget/widget.hh>
 
-#include <array>
 #include <functional>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace pcs::gui::working {
 
 using namespace creeper;
 
 struct ActionPanelContext {
-    creeper::ThemeManager* manager = nullptr;
-    pcs::AssetsManager* assets     = nullptr;
+    creeper::ThemeManager* manager      = nullptr;
+    pcs::AssetsManager* assets          = nullptr;
+    pcs::Runtime* runtime               = nullptr;
+    pcs::gui::interaction::Mouse* mouse = nullptr;
 
     std::function<void()> refresh_assets_list;
     std::function<void(std::string const&)> select_asset;
@@ -35,78 +35,24 @@ struct AssetActionPanel {
     virtual auto clear() noexcept -> void                           = 0;
 };
 
-struct PointcloudActionPanel final : AssetActionPanel {
-    explicit PointcloudActionPanel(ActionPanelContext context, QFont const& font);
+class ActionPanelRegistry {
+public:
+    using Factory =
+        std::function<std::unique_ptr<AssetActionPanel>(ActionPanelContext, QFont const&)>;
 
-    auto widget() const noexcept -> QWidget* override;
-    auto bind_asset(std::string const& id) noexcept -> void override;
-    auto clear() noexcept -> void override;
-
-private:
-    ActionPanelContext context;
-    std::string selected_asset_id;
-
-    std::array<std::shared_ptr<MutableDouble>, 4> color_channels {
-        std::make_shared<MutableDouble>(),
-        std::make_shared<MutableDouble>(),
-        std::make_shared<MutableDouble>(),
-        std::make_shared<MutableDouble>(),
-    };
-
-    text_field::internal::BasicTextField* resolution_input       = nullptr;
-    text_field::internal::BasicTextField* points_limit_input     = nullptr;
-    text_field::internal::BasicTextField* height_limit_input     = nullptr;
-    text_field::internal::BasicTextField* influence_radius_input = nullptr;
-    text_field::internal::BasicTextField* z_area_start_input     = nullptr;
-    text_field::internal::BasicTextField* z_area_end_input       = nullptr;
-
-    OutlinedButton* save_button     = nullptr;
-    OutlinedButton* generate_button = nullptr;
-    FilledCard* root                = nullptr;
-};
-
-struct ModelActionPanel final : AssetActionPanel {
-    explicit ModelActionPanel(ActionPanelContext context, QFont const& font);
-
-    auto widget() const noexcept -> QWidget* override;
-    auto bind_asset(std::string const& id) noexcept -> void override;
-    auto clear() noexcept -> void override;
+    auto register_factory(pcs::AssetKind, Factory) noexcept -> void;
+    auto create(pcs::AssetKind, ActionPanelContext, QFont const&) const noexcept
+        -> std::unique_ptr<AssetActionPanel>;
 
 private:
-    ActionPanelContext context;
-    std::string selected_asset_id;
-
-    text_field::internal::BasicTextField* density_input         = nullptr;
-    text_field::internal::BasicTextField* sample_distance_input = nullptr;
-    text_field::internal::BasicTextField* unit_scale_input      = nullptr;
-    text_field::internal::BasicTextField* max_points_input      = nullptr;
-
-    OutlinedButton* convert_button = nullptr;
-    FilledCard* root               = nullptr;
-};
-
-struct PngMapActionPanel final : AssetActionPanel {
-    explicit PngMapActionPanel(ActionPanelContext context, QFont const& font);
-
-    auto widget() const noexcept -> QWidget* override;
-    auto bind_asset(std::string const& id) noexcept -> void override;
-    auto clear() noexcept -> void override;
-
-private:
-    ActionPanelContext context;
-    std::string selected_asset_id;
-
-    OutlinedButton* save_button = nullptr;
-    FilledCard* root            = nullptr;
+    std::unordered_map<pcs::AssetKind, Factory> factories;
 };
 
 struct ActionPanelHost {
     static constexpr auto kPlaceholderIndex = 0;
-    static constexpr auto kPointcloudIndex  = 1;
-    static constexpr auto kModelIndex       = 2;
-    static constexpr auto kPngMapIndex      = 3;
 
-    explicit ActionPanelHost(ActionPanelContext context, QFont const& font);
+    explicit ActionPanelHost(
+        ActionPanelContext context, ActionPanelRegistry const* registry, QFont const& font);
 
     auto widget() const noexcept -> QWidget*;
     auto clear() noexcept -> void;
@@ -114,15 +60,18 @@ struct ActionPanelHost {
 
 private:
     auto sync_current_panel_height() noexcept -> void;
+    auto ensure_panel(pcs::AssetKind) noexcept -> AssetActionPanel*;
 
-    Widget* root   = nullptr;
-    Stacked* stack = nullptr;
+    ActionPanelContext context;
+    ActionPanelRegistry const* registry = nullptr;
+    QFont font;
 
-    std::unique_ptr<AssetActionPanel> pointcloud_panel;
-    std::unique_ptr<AssetActionPanel> model_panel;
-    std::unique_ptr<AssetActionPanel> png_map_panel;
-
+    Widget* root         = nullptr;
+    Stacked* stack       = nullptr;
     QWidget* placeholder = nullptr;
+
+    std::unordered_map<pcs::AssetKind, std::unique_ptr<AssetActionPanel>> panels;
+    std::unordered_map<pcs::AssetKind, int> panel_indices;
 };
 
 }

--- a/src/gui/working/asset-details.cc
+++ b/src/gui/working/asset-details.cc
@@ -1,0 +1,20 @@
+#include "gui/working/asset-details.hh"
+
+namespace pcs::gui::working {
+
+auto AssetDetailsRegistry::register_provider(pcs::AssetKind kind, Provider provider) noexcept
+    -> void {
+    providers[kind] = std::move(provider);
+}
+
+auto AssetDetailsRegistry::provide(pcs::AssetKind kind, pcs::AssetsManager& assets,
+    std::string const& id) const noexcept -> std::optional<AssetDetails> {
+    auto iter = providers.find(kind);
+    if (iter == providers.end() || !iter->second) {
+        return std::nullopt;
+    }
+
+    return iter->second(assets, id);
+}
+
+}

--- a/src/gui/working/asset-details.hh
+++ b/src/gui/working/asset-details.hh
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "core/assets.hh"
+
+#include <optional>
+#include <string>
+#include <functional>
+#include <unordered_map>
+
+#include <QString>
+
+namespace pcs::gui::working {
+
+struct AssetDetails {
+    QString type;
+    QString size;
+    QString info;
+};
+
+class AssetDetailsRegistry {
+public:
+    using Provider = std::function<std::optional<AssetDetails>(pcs::AssetsManager&, std::string const&)>;
+
+    auto register_provider(pcs::AssetKind, Provider) noexcept -> void;
+    auto provide(pcs::AssetKind, pcs::AssetsManager&, std::string const&) const noexcept
+        -> std::optional<AssetDetails>;
+
+private:
+    std::unordered_map<pcs::AssetKind, Provider> providers;
+};
+
+}

--- a/src/gui/working/open-control.cc
+++ b/src/gui/working/open-control.cc
@@ -1,0 +1,70 @@
+#include "gui/working/open-control.hh"
+
+#include <cctype>
+#include <algorithm>
+#include <filesystem>
+#include <format>
+#include <ranges>
+
+#include <QStringList>
+
+namespace pcs::gui::working {
+
+namespace {
+
+auto normalized_extension(std::string extension) -> std::string {
+    std::ranges::transform(extension, extension.begin(), [](unsigned char ch) {
+        return static_cast<char>(std::tolower(ch));
+    });
+    return extension;
+}
+
+}
+
+auto OpenControl::register_format(Format format) noexcept -> void {
+    for (auto& extension : format.extensions) {
+        extension = normalized_extension(extension);
+    }
+    formats.push_back(std::move(format));
+}
+
+auto OpenControl::dialog_filter() const noexcept -> QString {
+    auto all_patterns = QStringList { };
+    auto sections     = QStringList { };
+
+    for (auto const& format : formats) {
+        if (!format.dialog_pattern.empty()) {
+            all_patterns.append(QString::fromStdString(format.dialog_pattern));
+            sections.append(QString::fromStdString(
+                std::format("{} ({})", format.label, format.dialog_pattern)));
+        }
+    }
+
+    if (!all_patterns.isEmpty()) {
+        sections.push_front(QString("资产文件 (%1)").arg(all_patterns.join(' ')));
+    }
+
+    return sections.join(";;");
+}
+
+auto OpenControl::open(std::string const& path) const noexcept -> std::expected<void, std::string> {
+    const auto extension = normalized_extension(std::filesystem::path(path).extension().string());
+    auto const* format   = find_format(extension);
+    if (format == nullptr) {
+        return std::unexpected { std::format("Unsupported asset file: {}", path) };
+    }
+
+    return format->open(path);
+}
+
+auto OpenControl::find_format(std::string_view extension) const noexcept -> Format const* {
+    for (auto const& format : formats) {
+        if (std::ranges::find(format.extensions, extension) != format.extensions.end()) {
+            return &format;
+        }
+    }
+
+    return nullptr;
+}
+
+}

--- a/src/gui/working/open-control.hh
+++ b/src/gui/working/open-control.hh
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <expected>
+#include <functional>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <QString>
+
+namespace pcs::gui::working {
+
+class OpenControl {
+public:
+    struct Format {
+        std::string label;
+        std::string dialog_pattern;
+        std::vector<std::string> extensions;
+        std::function<std::expected<void, std::string>(std::string const& path)> open;
+    };
+
+    auto register_format(Format) noexcept -> void;
+
+    auto dialog_filter() const noexcept -> QString;
+    auto open(std::string const& path) const noexcept -> std::expected<void, std::string>;
+
+private:
+    auto find_format(std::string_view extension) const noexcept -> Format const*;
+
+    std::vector<Format> formats;
+};
+
+}

--- a/src/gui/working/panels/common.cc
+++ b/src/gui/working/panels/common.cc
@@ -1,0 +1,129 @@
+#include "gui/working/panels/common.hh"
+
+#include <qfiledialog.h>
+#include <qmessagebox.h>
+
+#include <filesystem>
+
+namespace pcs::gui::working::panels {
+
+auto save_pointcloud_location(std::string const& suggested_name) noexcept
+    -> std::expected<std::string, std::string_view> {
+    auto filename = std::filesystem::path(suggested_name);
+    if (filename.extension() != ".pcd") {
+        filename.replace_extension(".pcd");
+    }
+
+    const auto location = QFileDialog::getSaveFileName(
+        nullptr, "保存点云", QString::fromStdString(filename.string()), "点云文件 (*.pcd)");
+
+    if (location.isEmpty()) {
+        return std::unexpected { "用户取消保存点云" };
+    }
+
+    return location.toStdString();
+}
+
+auto save_png_map_location(std::string const& suggested_name) noexcept
+    -> std::expected<std::string, std::string_view> {
+    auto filename = std::filesystem::path(suggested_name);
+    if (filename.extension() != ".png") {
+        filename.replace_extension(".png");
+    }
+
+    const auto location = QFileDialog::getSaveFileName(
+        nullptr, "保存 PNG 地图", QString::fromStdString(filename.string()), "PNG 图片 (*.png)");
+
+    if (location.isEmpty()) {
+        return std::unexpected { "用户取消保存 PNG 地图" };
+    }
+
+    return location.toStdString();
+}
+
+auto parse_double_input(creeper::OutlinedTextField& input, double fallback, double minimum) noexcept
+    -> double {
+    auto parsed = double { };
+    auto ok     = false;
+    parsed      = input.text().toDouble(&ok);
+
+    if (!ok || parsed < minimum) {
+        parsed = fallback;
+    }
+
+    auto normalized = QString::number(parsed, 'f', 6);
+    while (normalized.contains('.') && normalized.endsWith('0')) {
+        normalized.chop(1);
+    }
+    if (normalized.endsWith('.')) {
+        normalized.chop(1);
+    }
+    if (normalized == "-0") {
+        normalized = "0";
+    }
+
+    input.setText(normalized);
+    return parsed;
+}
+
+auto parse_size_input(creeper::OutlinedTextField& input, std::size_t fallback,
+    std::size_t minimum) noexcept -> std::size_t {
+    auto ok     = false;
+    auto parsed = input.text().toULongLong(&ok);
+
+    if (!ok || parsed < minimum) {
+        parsed = fallback;
+    }
+
+    input.setText(QString::number(parsed));
+    return static_cast<std::size_t>(parsed);
+}
+
+auto make_parameter_field(creeper::theme::pro::ThemeManager const& theme, QFont const& font,
+    int width, QString const& default_value) noexcept -> creeper::OutlinedTextField* {
+    const auto measurements = compact_text_field_measurements();
+
+    return new creeper::OutlinedTextField {
+        theme,
+        creeper::text_field::pro::Font { font },
+        creeper::text_field::pro::FixedWidth { width },
+        creeper::widget::pro::Apply {
+            [measurements](auto& self) { self.set_measurements(measurements); } },
+        creeper::common::pro::Text<creeper::text_field::pro::Token> { default_value },
+    };
+}
+
+auto compact_text_field_measurements() noexcept -> creeper::OutlinedTextField::Measurements {
+    auto measurements = creeper::OutlinedTextField::Measurements { };
+
+    measurements.container_height     = 26;
+    measurements.icon_rect_size       = 16;
+    measurements.input_rect_size      = 16;
+    measurements.label_rect_size      = 12;
+    measurements.standard_font_height = 13;
+
+    measurements.col_padding                      = 4;
+    measurements.row_padding_without_icons        = 10;
+    measurements.row_padding_with_icons           = 8;
+    measurements.row_padding_populated_label_text = 0;
+    measurements.padding_icons_text               = 8;
+
+    measurements.supporting_text_and_character_counter_top_padding = 2;
+    measurements.supporting_text_and_character_counter_row_padding = 8;
+
+    return measurements;
+}
+
+auto confirm_large_pointcloud_warning(std::uintmax_t bytes) noexcept -> bool {
+    const auto size_mb = static_cast<double>(bytes) / (1024.0 * 1024.0);
+    const auto message = QString("当前点云大小为 %1 MB（超过 100 MB），生成 PNG "
+                                 "地图可能耗时较长，是否继续？")
+                             .arg(size_mb, 0, 'f', 1);
+
+    const auto answer = QMessageBox::warning(
+        nullptr, "大体积点云提示", message, QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
+
+    return answer == QMessageBox::Yes;
+}
+
+}

--- a/src/gui/working/panels/common.hh
+++ b/src/gui/working/panels/common.hh
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <creeper-qt/utility/theme/theme.hh>
+#include <creeper-qt/widget/text-fields.hh>
+
+#include <expected>
+#include <string>
+#include <string_view>
+
+namespace pcs::gui::working::panels {
+
+auto save_pointcloud_location(std::string const& suggested_name) noexcept
+    -> std::expected<std::string, std::string_view>;
+
+auto save_png_map_location(std::string const& suggested_name) noexcept
+    -> std::expected<std::string, std::string_view>;
+
+auto parse_double_input(creeper::OutlinedTextField& input, double fallback, double minimum) noexcept
+    -> double;
+
+auto parse_size_input(creeper::OutlinedTextField& input, std::size_t fallback,
+    std::size_t minimum) noexcept -> std::size_t;
+
+auto make_parameter_field(creeper::theme::pro::ThemeManager const& theme, QFont const& font,
+    int width, QString const& default_value) noexcept -> creeper::OutlinedTextField*;
+
+auto compact_text_field_measurements() noexcept -> creeper::OutlinedTextField::Measurements;
+
+auto confirm_large_pointcloud_warning(std::uintmax_t bytes) noexcept -> bool;
+
+}

--- a/src/gui/working/panels/model-panel.cc
+++ b/src/gui/working/panels/model-panel.cc
@@ -1,0 +1,187 @@
+#include "gui/working/panels/model-panel.hh"
+
+#include "core/events/process/model-to-pointcloud.hh"
+#include "gui/working/panels/common.hh"
+
+#include <creeper-qt/layout/linear.hh>
+#include <creeper-qt/widget/buttons/outlined-button.hh>
+#include <creeper-qt/widget/cards/filled-card.hh>
+#include <creeper-qt/widget/text.hh>
+
+#include <spdlog/spdlog.h>
+#include <QTimer>
+
+#include <chrono>
+#include <future>
+
+namespace pcs::gui::working {
+
+namespace {
+
+    class ModelPanel final : public AssetActionPanel {
+    public:
+        explicit ModelPanel(ActionPanelContext context, QFont const& font)
+            : context { std::move(context) }
+            , assets { *this->context.assets }
+            , runtime { *this->context.runtime }
+            , mouse { *this->context.mouse } {
+            const auto theme = creeper::theme::pro::ThemeManager { *this->context.manager };
+
+            const auto make_input_row = [=](std::string_view label,
+                                            creeper::OutlinedTextField*& input,
+                                            QString const& default_value) {
+                auto* field = panels::make_parameter_field(theme, font, 116, default_value);
+                input       = field;
+
+                return new creeper::Row {
+                    creeper::row::pro::Spacing { 8 },
+                    creeper::row::pro::Item<creeper::Text> {
+                        { 0, Qt::AlignVCenter },
+                        theme,
+                        creeper::text::pro::Font { font },
+                        creeper::text::pro::Text { QString::fromStdString(std::string { label }) },
+                        creeper::text::pro::WordWrap { true },
+                        creeper::text::pro::Alignment { Qt::AlignVCenter | Qt::AlignLeft },
+                        creeper::widget::pro::FixedWidth { 92 },
+                    },
+                    creeper::row::pro::Item { { 1, Qt::AlignVCenter }, field },
+                };
+            };
+
+            convert_button = new creeper::OutlinedButton {
+                theme,
+                creeper::widget::pro::FixedHeight { 36 },
+                creeper::widget::pro::MinimumWidth { 180 },
+                creeper::button::pro::Text { "转换为点云" },
+            };
+
+            QObject::connect(convert_button, &creeper::OutlinedButton::clicked, [this](bool) {
+                if (selected_asset_id.empty()) {
+                    return;
+                }
+                if (!convert_button->isEnabled()) {
+                    return;
+                }
+
+                auto parameters    = pcs::ModelToPointcloudParameters { };
+                parameters.density = panels::parse_double_input(*density_input, 10.0, 0.01);
+                parameters.sample_distance =
+                    panels::parse_double_input(*sample_distance_input, 0.0, 0.0);
+                parameters.unit_scale = panels::parse_double_input(*unit_scale_input, 1.0, 1e-6);
+                parameters.max_points = panels::parse_size_input(*max_points_input, 0, 0);
+
+                const auto handle = assets.get_model_handle(selected_asset_id);
+                if (!handle.has_value() || handle.value() == nullptr) {
+                    spdlog::error("模型转点云失败: 模型资产不可用");
+                    return;
+                }
+
+                auto event_context        = std::make_unique<pcs::event::ConvertModelToPointcloud::Context>();
+                event_context->model      = handle.value()->model_data();
+                event_context->parameters = parameters;
+
+                const auto source_id = selected_asset_id;
+                auto future          = std::make_shared<std::future<pcs::event::ConvertModelToPointcloud::Result>>(
+                    runtime.submit<pcs::event::ConvertModelToPointcloud>(std::move(event_context)));
+
+                set_convert_busy(true);
+
+                auto* watcher = new QTimer { convert_button };
+                watcher->setInterval(30);
+                QObject::connect(watcher, &QTimer::timeout,
+                    [this, watcher, future, source_id]() mutable {
+                        if (future->wait_for(std::chrono::seconds { 0 }) != std::future_status::ready) {
+                            return;
+                        }
+
+                        watcher->stop();
+                        watcher->deleteLater();
+                        set_convert_busy(false);
+
+                        auto result = future->get();
+                        if (!result.has_value()) {
+                            spdlog::error("模型转点云失败: {}", result.error());
+                            return;
+                        }
+
+                        auto upsert_result = assets.upsert_generated_pointcloud(source_id, result.value());
+                        if (!upsert_result.has_value()) {
+                            spdlog::error("模型转点云失败: {}", upsert_result.error());
+                            return;
+                        }
+
+                        this->context.refresh_assets_list();
+                        this->context.select_asset(*upsert_result);
+                    });
+                watcher->start();
+            });
+
+            root = new creeper::FilledCard {
+                theme,
+                creeper::card::pro::LevelLow,
+                creeper::card::pro::Layout<creeper::Col> {
+                    creeper::col::pro::Alignment { Qt::AlignTop },
+                    creeper::col::pro::Margin { 10 },
+                    creeper::col::pro::Spacing { 10 },
+                    creeper::col::pro::Item<creeper::Text> {
+                        theme,
+                        creeper::text::pro::Font { font },
+                        creeper::text::pro::Text { "模型操作" },
+                        creeper::text::pro::Alignment { Qt::AlignHCenter },
+                    },
+                    creeper::col::pro::Item<creeper::FilledCard> {
+                        theme,
+                        creeper::card::pro::LevelLowest,
+                        creeper::card::pro::Layout<creeper::Col> {
+                            creeper::col::pro::Margin { 8 },
+                            creeper::col::pro::Spacing { 4 },
+                            creeper::col::pro::Item {
+                                make_input_row("点云密度（倍）", density_input, "10") },
+                            creeper::col::pro::Item {
+                                make_input_row("采样间距（m）", sample_distance_input, "0") },
+                            creeper::col::pro::Item {
+                                make_input_row("缩放比例（倍）", unit_scale_input, "1") },
+                            creeper::col::pro::Item {
+                                make_input_row("最大点数（点）", max_points_input, "0") },
+                        },
+                    },
+                    creeper::col::pro::Item { convert_button },
+                },
+            };
+        }
+
+        auto widget() const noexcept -> QWidget* override { return root; }
+
+        auto bind_asset(std::string const& id) noexcept -> void override { selected_asset_id = id; }
+
+        auto clear() noexcept -> void override { selected_asset_id.clear(); }
+
+    private:
+        auto set_convert_busy(bool busy) noexcept -> void {
+            convert_button->setDisabled(busy);
+            convert_button->setText(busy ? QString::fromUtf8("生成中...") : "转换为点云");
+        }
+
+        ActionPanelContext context;
+        pcs::AssetsManager& assets;
+        pcs::Runtime& runtime;
+        pcs::gui::interaction::Mouse& mouse;
+        std::string selected_asset_id;
+
+        creeper::OutlinedTextField* density_input         = nullptr;
+        creeper::OutlinedTextField* sample_distance_input = nullptr;
+        creeper::OutlinedTextField* unit_scale_input      = nullptr;
+        creeper::OutlinedTextField* max_points_input      = nullptr;
+
+        creeper::OutlinedButton* convert_button = nullptr;
+        creeper::FilledCard* root               = nullptr;
+    };
+
+}
+
+auto make_model_panel(ActionPanelContext context, QFont const& font)
+    -> std::unique_ptr<AssetActionPanel> {
+    return std::make_unique<ModelPanel>(std::move(context), font);
+}
+
+}

--- a/src/gui/working/panels/model-panel.hh
+++ b/src/gui/working/panels/model-panel.hh
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "gui/working/action-panels.hh"
+
+#include <memory>
+
+namespace pcs::gui::working {
+
+auto make_model_panel(ActionPanelContext context, QFont const& font)
+    -> std::unique_ptr<AssetActionPanel>;
+
+}

--- a/src/gui/working/panels/png-map-panel.cc
+++ b/src/gui/working/panels/png-map-panel.cc
@@ -1,0 +1,305 @@
+#include "gui/working/panels/png-map-panel.hh"
+
+#include "gui/interaction/png-edit-tools.hh"
+#include "gui/working/panels/common.hh"
+
+#include <creeper-qt/layout/linear.hh>
+#include <creeper-qt/layout/stacked.hh>
+#include <creeper-qt/utility/material-icon.hh>
+#include <creeper-qt/widget/buttons/icon-button.hh>
+#include <creeper-qt/widget/buttons/outlined-button.hh>
+#include <creeper-qt/widget/cards/filled-card.hh>
+#include <creeper-qt/widget/text.hh>
+#include <creeper-qt/widget/widget.hh>
+
+#include <spdlog/spdlog.h>
+
+#include <algorithm>
+#include <tuple>
+#include <vector>
+
+namespace pcs::gui::working {
+
+namespace {
+
+    class PngMapPanel final : public AssetActionPanel {
+    public:
+        explicit PngMapPanel(ActionPanelContext context, QFont const& font)
+            : context { std::move(context) }
+            , assets { *this->context.assets }
+            , mouse { *this->context.mouse } {
+            namespace ib = creeper::icon_button::pro;
+
+            const auto theme        = creeper::theme::pro::ThemeManager { *this->context.manager };
+            const auto current_tool = mouse.png_edit_tool();
+
+            auto mode_label_font = font;
+            mode_label_font.setPointSize(std::max(8, font.pointSize() - 1));
+
+            const auto make_input_row = [=](std::string_view label,
+                                            creeper::OutlinedTextField*& input,
+                                            QString const& default_value) {
+                auto* field = panels::make_parameter_field(theme, font, 116, default_value);
+                input       = field;
+
+                return new creeper::Row {
+                    creeper::row::pro::Spacing { 8 },
+                    creeper::row::pro::Item<creeper::Text> {
+                        { 0, Qt::AlignVCenter },
+                        theme,
+                        creeper::text::pro::Font { font },
+                        creeper::text::pro::Text { QString::fromStdString(std::string { label }) },
+                        creeper::text::pro::WordWrap { true },
+                        creeper::text::pro::Alignment { Qt::AlignVCenter | Qt::AlignLeft },
+                        creeper::widget::pro::FixedWidth { 92 },
+                    },
+                    creeper::row::pro::Item { { 1, Qt::AlignVCenter }, field },
+                };
+            };
+
+            const auto default_line_width = static_cast<qulonglong>(mouse.png_edit_line_width());
+            const auto default_point_size = static_cast<qulonglong>(mouse.png_edit_point_size());
+            const auto default_erase_size = static_cast<qulonglong>(mouse.png_edit_erase_size());
+
+            const auto mode_button_base = std::tuple {
+                ib::ThemeManager { *this->context.manager },
+                ib::ColorFilled,
+                ib::ShapeRound,
+                ib::WidthDefault,
+                ib::FixedSize { creeper::IconButton::kExtraSmallContainerSize },
+                ib::Font {
+                    creeper::material::round::font, creeper::IconButton::kExtraSmallFontIconSize },
+            };
+
+            const auto make_mode_item = [this, theme, mode_label_font, mode_button_base,
+                                            current_tool](pcs::gui::interaction::PngEditTool tool,
+                                            QString const& label, QString const& icon) -> QWidget* {
+                namespace ib = creeper::icon_button::pro;
+
+                auto* button = new creeper::IconButton {
+                    mode_button_base,
+                    tool == current_tool ? ib::TypesToggleSelected : ib::TypesToggleUnselected,
+                    ib::FontIcon { icon },
+                    ib::ToolTip { QString("模式: %1").arg(label) },
+                    ib::Clickable { [this, tool] {
+                        if (selected_asset_id.empty()) {
+                            return;
+                        }
+
+                        sync_inputs_into_mouse();
+                        mouse.set_selected_asset(selected_asset_id, pcs::AssetKind::PngMap);
+                        mouse.set_png_edit_tool(tool);
+                        mouse.set_mode(pcs::gui::interaction::MouseModeId::PngEdit);
+                        mouse.set_status(
+                            QString("PNG 编辑 | 模式: %1").arg(png_edit_tool_descriptor(tool).label));
+                        sync_tool_buttons();
+                    } },
+                };
+
+                mode_buttons.push_back(button);
+                mode_button_tools.push_back(tool);
+
+                return new creeper::Widget {
+                    creeper::widget::pro::Layout<creeper::Col> {
+                        creeper::col::pro::Spacing { 2 },
+                        creeper::col::pro::Alignment { Qt::AlignHCenter },
+                        creeper::col::pro::Item { { 0, Qt::AlignHCenter }, button },
+                        creeper::col::pro::Item<creeper::Text> {
+                            { 0, Qt::AlignHCenter },
+                            theme,
+                            creeper::text::pro::Font { mode_label_font },
+                            creeper::text::pro::Text { label },
+                            creeper::text::pro::Alignment { Qt::AlignHCenter },
+                            creeper::widget::pro::FixedWidth {
+                                creeper::IconButton::kExtraSmallContainerSize.width() },
+                        },
+                    },
+                };
+            };
+
+            auto* tool_row = new creeper::Row {
+                creeper::row::pro::Spacing { 6 },
+                creeper::row::pro::Alignment { Qt::AlignHCenter },
+            };
+            for (auto const& descriptor : pcs::gui::interaction::default_png_edit_tool_descriptors()) {
+                tool_row->addWidget(
+                    make_mode_item(descriptor.id, descriptor.label, descriptor.icon));
+            }
+
+            auto* free_param = new creeper::Text {
+                theme,
+                creeper::text::pro::Font { font },
+                creeper::text::pro::Text { "自由模式：用于查看坐标，可拖动视图" },
+                creeper::text::pro::WordWrap { true },
+            };
+
+            auto* line_param = new creeper::Widget {
+                creeper::widget::pro::Layout<creeper::Col> {
+                    creeper::col::pro::Spacing { 4 },
+                    creeper::col::pro::Item { make_input_row(
+                        "线宽（px）", line_width_input, QString::number(default_line_width)) },
+                },
+            };
+
+            auto* point_param = new creeper::Widget {
+                creeper::widget::pro::Layout<creeper::Col> {
+                    creeper::col::pro::Spacing { 4 },
+                    creeper::col::pro::Item { make_input_row(
+                        "点大小（px）", point_size_input, QString::number(default_point_size)) },
+                },
+            };
+
+            auto* erase_param = new creeper::Widget {
+                creeper::widget::pro::Layout<creeper::Col> {
+                    creeper::col::pro::Spacing { 4 },
+                    creeper::col::pro::Item { make_input_row(
+                        "擦除大小（px）", erase_size_input, QString::number(default_erase_size)) },
+                },
+            };
+
+            param_stack = new creeper::Stacked {
+                creeper::stacked::pro::Item { free_param },
+                creeper::stacked::pro::Item { line_param },
+                creeper::stacked::pro::Item { point_param },
+                creeper::stacked::pro::Item { erase_param },
+                creeper::stacked::pro::CurrentIndex {
+                    pcs::gui::interaction::png_edit_tool_descriptor(current_tool).param_index },
+            };
+
+            save_button = new creeper::OutlinedButton {
+                theme,
+                creeper::widget::pro::FixedHeight { 36 },
+                creeper::widget::pro::MinimumWidth { 180 },
+                creeper::button::pro::Text { "保存 PNG 地图" },
+            };
+
+            QObject::connect(save_button, &creeper::OutlinedButton::clicked, [this](bool) {
+                if (selected_asset_id.empty()) {
+                    return;
+                }
+
+                const auto suggested_name =
+                    assets.get_asset_name(selected_asset_id).value_or("map.png");
+                if (auto location = panels::save_png_map_location(suggested_name)) {
+                    const auto result = assets.save_png_map_asset(selected_asset_id, *location);
+                    if (!result.has_value()) {
+                        spdlog::error("保存 PNG 地图资产失败: {}", result.error());
+                        return;
+                    }
+
+                    this->context.refresh_assets_list();
+                    this->context.select_asset(selected_asset_id);
+                }
+            });
+
+            root = new creeper::FilledCard {
+                theme,
+                creeper::card::pro::LevelLow,
+                creeper::card::pro::Layout<creeper::Col> {
+                    creeper::col::pro::Alignment { Qt::AlignTop },
+                    creeper::col::pro::Margin { 10 },
+                    creeper::col::pro::Spacing { 10 },
+                    creeper::col::pro::Item<creeper::Text> {
+                        theme,
+                        creeper::text::pro::Font { font },
+                        creeper::text::pro::Text { "PNG 地图操作" },
+                        creeper::text::pro::Alignment { Qt::AlignHCenter },
+                    },
+                    creeper::col::pro::Item<creeper::FilledCard> {
+                        theme,
+                        creeper::card::pro::LevelLowest,
+                        creeper::card::pro::Layout<creeper::Col> {
+                            creeper::col::pro::Margin { 8 },
+                            creeper::col::pro::Spacing { 6 },
+                            creeper::col::pro::Item { tool_row },
+                        },
+                    },
+                    creeper::col::pro::Item<creeper::FilledCard> {
+                        theme,
+                        creeper::card::pro::LevelLowest,
+                        creeper::card::pro::Layout<creeper::Col> {
+                            creeper::col::pro::Margin { 8 },
+                            creeper::col::pro::Spacing { 4 },
+                            creeper::col::pro::Item { param_stack },
+                        },
+                    },
+                    creeper::col::pro::Item { save_button },
+                },
+            };
+        }
+
+        auto widget() const noexcept -> QWidget* override { return root; }
+
+        auto bind_asset(std::string const& id) noexcept -> void override {
+            selected_asset_id = id;
+
+            sync_inputs_into_mouse();
+            mouse.set_selected_asset(id, pcs::AssetKind::PngMap);
+            mouse.set_mode(pcs::gui::interaction::MouseModeId::PngEdit);
+            mouse.set_status(QString("PNG 编辑 | 模式: %1")
+                                 .arg(pcs::gui::interaction::png_edit_tool_descriptor(
+                                     mouse.png_edit_tool())
+                                          .label));
+
+            sync_tool_buttons();
+        }
+
+        auto clear() noexcept -> void override {
+            selected_asset_id.clear();
+
+            if (mouse.mode() == pcs::gui::interaction::MouseModeId::PngEdit) {
+                mouse.set_mode(pcs::gui::interaction::MouseModeId::None);
+            }
+        }
+
+    private:
+        auto sync_inputs_into_mouse() noexcept -> void {
+            const auto line_width =
+                panels::parse_size_input(*line_width_input, mouse.png_edit_line_width(), 1);
+            const auto point_size =
+                panels::parse_size_input(*point_size_input, mouse.png_edit_point_size(), 1);
+            const auto erase_size =
+                panels::parse_size_input(*erase_size_input, mouse.png_edit_erase_size(), 1);
+
+            mouse.set_png_edit_line_width(line_width);
+            mouse.set_png_edit_point_size(point_size);
+            mouse.set_png_edit_erase_size(erase_size);
+        }
+
+        auto sync_tool_buttons() noexcept -> void {
+            const auto current_tool = mouse.png_edit_tool();
+            for (std::size_t i = 0; i < mode_buttons.size() && i < mode_button_tools.size(); ++i) {
+                mode_buttons[i]->set_selected(mode_button_tools[i] == current_tool);
+            }
+
+            param_stack->setCurrentIndex(
+                pcs::gui::interaction::png_edit_tool_descriptor(current_tool).param_index);
+        }
+
+        ActionPanelContext context;
+        pcs::AssetsManager& assets;
+        pcs::gui::interaction::Mouse& mouse;
+
+        std::string selected_asset_id;
+
+        std::vector<creeper::IconButton*> mode_buttons;
+        std::vector<pcs::gui::interaction::PngEditTool> mode_button_tools;
+
+        creeper::OutlinedTextField* line_width_input = nullptr;
+        creeper::OutlinedTextField* point_size_input = nullptr;
+        creeper::OutlinedTextField* erase_size_input = nullptr;
+
+        creeper::Stacked* param_stack = nullptr;
+
+        creeper::OutlinedButton* save_button = nullptr;
+        creeper::FilledCard* root            = nullptr;
+    };
+
+}
+
+auto make_png_map_panel(ActionPanelContext context, QFont const& font)
+    -> std::unique_ptr<AssetActionPanel> {
+    return std::make_unique<PngMapPanel>(std::move(context), font);
+}
+
+}

--- a/src/gui/working/panels/png-map-panel.hh
+++ b/src/gui/working/panels/png-map-panel.hh
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "gui/working/action-panels.hh"
+
+#include <memory>
+
+namespace pcs::gui::working {
+
+auto make_png_map_panel(ActionPanelContext context, QFont const& font)
+    -> std::unique_ptr<AssetActionPanel>;
+
+}

--- a/src/gui/working/panels/pointcloud-panel.cc
+++ b/src/gui/working/panels/pointcloud-panel.cc
@@ -1,0 +1,390 @@
+#include "gui/working/panels/pointcloud-panel.hh"
+
+#include "core/events/process/pointcloud-to-png-map.hh"
+#include "gui/working/panels/common.hh"
+
+#include <creeper-qt/layout/linear.hh>
+#include <creeper-qt/utility/wrapper/mutable-value.hh>
+#include <creeper-qt/widget/buttons/outlined-button.hh>
+#include <creeper-qt/widget/cards/filled-card.hh>
+#include <creeper-qt/widget/sliders.hh>
+#include <creeper-qt/widget/text-fields.hh>
+#include <creeper-qt/widget/text.hh>
+
+#include <QCoreApplication>
+#include <QMetaObject>
+#include <QPointer>
+#include <QThreadPool>
+
+#include <spdlog/spdlog.h>
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <system_error>
+#include <tuple>
+
+namespace pcs::gui::working {
+
+namespace {
+
+    constexpr auto kLargePointcloudBytes = std::uintmax_t { 100 } * 1024U * 1024U;
+
+    class PointcloudPanel final : public AssetActionPanel {
+    public:
+        explicit PointcloudPanel(ActionPanelContext context, QFont const& font)
+            : context { std::move(context) }
+            , assets { *this->context.assets }
+            , mouse { *this->context.mouse } {
+            const auto theme = creeper::theme::pro::ThemeManager { *this->context.manager };
+
+            const auto update_color = [this] {
+                if (selected_asset_id.empty()) {
+                    return;
+                }
+
+                if (auto result = assets.get_pointcloud_handle(selected_asset_id)) {
+                    auto* handle = result.value();
+                    handle->set_overall_color(*color_channels[0], *color_channels[1],
+                        *color_channels[2], *color_channels[3]);
+                    assets.update_renderer();
+                }
+            };
+
+            const auto make_slider = [=](std::shared_ptr<creeper::MutableDouble> channel,
+                                         std::string_view name) {
+                auto measurement          = creeper::Slider::Measurements::Xs();
+                measurement.handle_height = 22;
+
+                return new creeper::Row {
+                    creeper::row::pro::Spacing { 8 },
+                    creeper::row::pro::Item<creeper::Text> {
+                        theme,
+                        creeper::MutableTransform {
+                            [name](creeper::Text& self, double value) {
+                                self.setText(QString("%1: %2")
+                                        .arg(QString::fromStdString(std::string { name }))
+                                        .arg(QString::number(value, 'f', 2)));
+                            },
+                            channel,
+                        },
+                        creeper::text::pro::Font { font },
+                    },
+                    creeper::row::pro::Item<creeper::Slider> {
+                        { 255 },
+                        theme,
+                        creeper::slider::pro::Measurements { measurement },
+                        creeper::MutableForward {
+                            creeper::slider::pro::Progress { 0 },
+                            channel,
+                        },
+                        creeper::slider::pro::FixedHeight { measurement.minimum_height() },
+                        creeper::slider::pro::OnValueChangeFinished {
+                            [=](double v) {
+                                *channel = v;
+                                update_color();
+                            },
+                        },
+                    },
+                };
+            };
+
+            const auto make_input_row = [=](std::string_view label,
+                                            creeper::OutlinedTextField*& input,
+                                            QString const& default_value) {
+                auto* field = panels::make_parameter_field(theme, font, 116, default_value);
+                input       = field;
+
+                return new creeper::Row {
+                    creeper::row::pro::Spacing { 8 },
+                    creeper::row::pro::Item<creeper::Text> {
+                        { 0, Qt::AlignVCenter },
+                        theme,
+                        creeper::text::pro::Font { font },
+                        creeper::text::pro::Text { QString::fromStdString(std::string { label }) },
+                        creeper::text::pro::WordWrap { true },
+                        creeper::text::pro::Alignment { Qt::AlignVCenter | Qt::AlignLeft },
+                        creeper::widget::pro::FixedWidth { 92 },
+                    },
+                    creeper::row::pro::Item { { 1, Qt::AlignVCenter }, field },
+                };
+            };
+
+            const auto make_dual_input_row = [=](std::string_view label,
+                                                 creeper::OutlinedTextField*& first,
+                                                 QString const& first_default,
+                                                 creeper::OutlinedTextField*& second,
+                                                 QString const& second_default) {
+                auto* first_field  = panels::make_parameter_field(theme, font, 56, first_default);
+                auto* second_field = panels::make_parameter_field(theme, font, 56, second_default);
+                first              = first_field;
+                second             = second_field;
+
+                return new creeper::Row {
+                    creeper::row::pro::Spacing { 8 },
+                    creeper::row::pro::Item<creeper::Text> {
+                        { 0, Qt::AlignVCenter },
+                        theme,
+                        creeper::text::pro::Font { font },
+                        creeper::text::pro::Text { QString::fromStdString(std::string { label }) },
+                        creeper::text::pro::WordWrap { true },
+                        creeper::text::pro::Alignment { Qt::AlignVCenter | Qt::AlignLeft },
+                        creeper::widget::pro::FixedWidth { 92 },
+                    },
+                    creeper::row::pro::Item<creeper::Row> {
+                        { 1, Qt::AlignVCenter },
+                        creeper::row::pro::Spacing { 4 },
+                        creeper::row::pro::Item { first_field },
+                        creeper::row::pro::Item { second_field },
+                    },
+                };
+            };
+
+            const auto set_generate_busy = [this](bool busy) {
+                generate_button->setDisabled(busy);
+                generate_button->setText(busy ? QString::fromUtf8("生成中") : "生成 PNG 地图");
+            };
+
+            const auto should_continue_large_generation = [this](std::size_t points_count) -> bool {
+                const auto path = assets.get_asset_path(selected_asset_id).value_or("");
+                if (!path.empty() && path != "<memory>") {
+                    auto error      = std::error_code { };
+                    const auto size = std::filesystem::file_size(path, error);
+                    if (!error && size > kLargePointcloudBytes) {
+                        return panels::confirm_large_pointcloud_warning(size);
+                    }
+                    return true;
+                }
+
+                constexpr auto bytes_per_point = sizeof(double) * 3U;
+                const auto estimated_size =
+                    static_cast<std::uintmax_t>(points_count) * bytes_per_point;
+                if (estimated_size > kLargePointcloudBytes) {
+                    return panels::confirm_large_pointcloud_warning(estimated_size);
+                }
+
+                return true;
+            };
+
+            save_button = new creeper::OutlinedButton {
+                theme,
+                creeper::widget::pro::FixedHeight { 36 },
+                creeper::widget::pro::MinimumWidth { 180 },
+                creeper::button::pro::Text { "保存点云" },
+            };
+
+            generate_button = new creeper::OutlinedButton {
+                theme,
+                creeper::widget::pro::FixedHeight { 36 },
+                creeper::widget::pro::MinimumWidth { 180 },
+                creeper::button::pro::Text { "生成 PNG 地图" },
+            };
+
+            QObject::connect(save_button, &creeper::OutlinedButton::clicked, [this](bool) {
+                if (selected_asset_id.empty()) {
+                    return;
+                }
+
+                const auto suggested =
+                    assets.get_asset_name(selected_asset_id).value_or("pointcloud.pcd");
+                if (auto location = panels::save_pointcloud_location(suggested)) {
+                    const auto result = assets.save_pointcloud_asset(selected_asset_id, *location);
+                    if (!result.has_value()) {
+                        spdlog::error("保存点云资产失败: {}", result.error());
+                        return;
+                    }
+
+                    this->context.refresh_assets_list();
+                    this->context.select_asset(selected_asset_id);
+                }
+            });
+
+            QObject::connect(generate_button, &creeper::OutlinedButton::clicked,
+                [this, set_generate_busy, should_continue_large_generation](bool) {
+                    if (selected_asset_id.empty()) {
+                        return;
+                    }
+                    if (!generate_button->isEnabled()) {
+                        return;
+                    }
+
+                    const auto handle_result = assets.get_pointcloud_handle(selected_asset_id);
+                    if (!handle_result.has_value()) {
+                        spdlog::error("点云句柄不可用");
+                        return;
+                    }
+
+                    auto source_points = handle_result.value()->get_positions();
+                    if (source_points.empty()) {
+                        spdlog::error("点云为空");
+                        return;
+                    }
+
+                    if (!should_continue_large_generation(source_points.size())) {
+                        return;
+                    }
+
+                    auto params         = pcs::PngMapParameters { };
+                    params.resolution   = panels::parse_double_input(*resolution_input, 0.1, 0.01);
+                    params.points_limit = panels::parse_size_input(*points_limit_input, 5, 1);
+                    params.height_limit = panels::parse_double_input(*height_limit_input, 0.1, 0.0);
+                    params.influence_radius =
+                        panels::parse_double_input(*influence_radius_input, 0.08, 0.0);
+                    params.z_area_start = panels::parse_double_input(*z_area_start_input, 0.0, 0.0);
+                    params.z_area_end   = panels::parse_double_input(*z_area_end_input, 1.0, 0.0);
+
+                    set_generate_busy(true);
+
+                    auto context_copy    = this->context;
+                    auto source_asset_id = std::string { selected_asset_id };
+                    auto button_guard    = QPointer<creeper::OutlinedButton> { generate_button };
+                    auto panel_guard     = QPointer<QWidget> { root };
+
+                    QThreadPool::globalInstance()->start(
+                        [context_copy, source_asset_id = std::move(source_asset_id),
+                            source_points = std::move(source_points), params, button_guard,
+                            panel_guard]() mutable {
+                            auto event_context =
+                                std::make_unique<pcs::event::ConvertPointcloudToPngMap::Context>();
+                            event_context->points     = std::move(source_points);
+                            event_context->parameters = params;
+
+                            auto compute_result =
+                                std::make_shared<pcs::event::ConvertPointcloudToPngMap::Result>(
+                                    pcs::event::ConvertPointcloudToPngMap::runtime_exec(
+                                        std::move(event_context)));
+
+                            QMetaObject::invokeMethod(
+                                QCoreApplication::instance(),
+                                [context_copy, source_asset_id = std::move(source_asset_id),
+                                    compute_result, button_guard, panel_guard]() {
+                                    if (button_guard) {
+                                        button_guard->setDisabled(false);
+                                        button_guard->setText("生成 PNG 地图");
+                                    }
+
+                                    if (!panel_guard) {
+                                        return;
+                                    }
+
+                                    if (!compute_result->has_value()) {
+                                        spdlog::error(
+                                            "点云生成 PNG 地图失败: {}", compute_result->error());
+                                        return;
+                                    }
+
+                                    const auto create_result =
+                                        context_copy.assets->upsert_generated_png_map(
+                                            source_asset_id, compute_result->value());
+                                    if (!create_result.has_value()) {
+                                        spdlog::error(
+                                            "创建 PNG 地图资产失败: {}", create_result.error());
+                                        return;
+                                    }
+
+                                    context_copy.refresh_assets_list();
+                                    context_copy.select_asset(*create_result);
+                                },
+                                Qt::QueuedConnection);
+                        });
+                });
+
+            root = new creeper::FilledCard {
+                theme,
+                creeper::card::pro::LevelLow,
+                creeper::card::pro::Layout<creeper::Col> {
+                    creeper::col::pro::Alignment { Qt::AlignTop },
+                    creeper::col::pro::Margin { 10 },
+                    creeper::col::pro::Spacing { 10 },
+                    creeper::col::pro::Item<creeper::Text> {
+                        theme,
+                        creeper::text::pro::Font { font },
+                        creeper::text::pro::Text { "点云操作" },
+                        creeper::text::pro::Alignment { Qt::AlignHCenter },
+                    },
+                    creeper::col::pro::Item<creeper::FilledCard> {
+                        theme,
+                        creeper::card::pro::LevelLowest,
+                        creeper::card::pro::Layout<creeper::Col> {
+                            creeper::col::pro::Margin { 8 },
+                            creeper::col::pro::Spacing { 4 },
+                            creeper::col::pro::Item { make_slider(color_channels[0], "R") },
+                            creeper::col::pro::Item { make_slider(color_channels[1], "G") },
+                            creeper::col::pro::Item { make_slider(color_channels[2], "B") },
+                            creeper::col::pro::Item { make_slider(color_channels[3], "A") },
+                        },
+                    },
+                    creeper::col::pro::Item<creeper::FilledCard> {
+                        theme,
+                        creeper::card::pro::LevelLowest,
+                        creeper::card::pro::Layout<creeper::Col> {
+                            creeper::col::pro::Margin { 8 },
+                            creeper::col::pro::Spacing { 4 },
+                            creeper::col::pro::Item {
+                                make_input_row("分辨率（m）", resolution_input, "0.1") },
+                            creeper::col::pro::Item {
+                                make_input_row("有效点云数（点）", points_limit_input, "5") },
+                            creeper::col::pro::Item {
+                                make_input_row("有效高度差（m）", height_limit_input, "0.1") },
+                            creeper::col::pro::Item {
+                                make_input_row("影响半径（m）", influence_radius_input, "0.08") },
+                            creeper::col::pro::Item { make_dual_input_row(
+                                "Z 区间（m）", z_area_start_input, "0", z_area_end_input, "1") },
+                            creeper::col::pro::Item { generate_button },
+                        },
+                    },
+                    creeper::col::pro::Item { save_button },
+                },
+            };
+        }
+
+        auto widget() const noexcept -> QWidget* override { return root; }
+
+        auto bind_asset(std::string const& id) noexcept -> void override {
+            selected_asset_id = id;
+
+            if (auto result = assets.get_pointcloud_handle(selected_asset_id)) {
+                auto* handle            = result.value();
+                std::tie(*color_channels[0], *color_channels[1], *color_channels[2],
+                    *color_channels[3]) = handle->get_overall_color();
+            }
+        }
+
+        auto clear() noexcept -> void override { selected_asset_id.clear(); }
+
+    private:
+        ActionPanelContext context;
+        pcs::AssetsManager& assets;
+        pcs::gui::interaction::Mouse& mouse;
+        std::string selected_asset_id;
+
+        std::array<std::shared_ptr<creeper::MutableDouble>, 4> color_channels {
+            std::make_shared<creeper::MutableDouble>(),
+            std::make_shared<creeper::MutableDouble>(),
+            std::make_shared<creeper::MutableDouble>(),
+            std::make_shared<creeper::MutableDouble>(),
+        };
+
+        creeper::OutlinedTextField* resolution_input       = nullptr;
+        creeper::OutlinedTextField* points_limit_input     = nullptr;
+        creeper::OutlinedTextField* height_limit_input     = nullptr;
+        creeper::OutlinedTextField* influence_radius_input = nullptr;
+        creeper::OutlinedTextField* z_area_start_input     = nullptr;
+        creeper::OutlinedTextField* z_area_end_input       = nullptr;
+
+        creeper::OutlinedButton* save_button     = nullptr;
+        creeper::OutlinedButton* generate_button = nullptr;
+        creeper::FilledCard* root                = nullptr;
+    };
+
+}
+
+auto make_pointcloud_panel(ActionPanelContext context, QFont const& font)
+    -> std::unique_ptr<AssetActionPanel> {
+    return std::make_unique<PointcloudPanel>(std::move(context), font);
+}
+
+}

--- a/src/gui/working/panels/pointcloud-panel.hh
+++ b/src/gui/working/panels/pointcloud-panel.hh
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "gui/working/action-panels.hh"
+
+#include <memory>
+
+namespace pcs::gui::working {
+
+auto make_pointcloud_panel(ActionPanelContext context, QFont const& font)
+    -> std::unique_ptr<AssetActionPanel>;
+
+}


### PR DESCRIPTION
Split app wiring into context modules, feature registration, and state assembly so open formats, action panels, asset details, and interaction features are registered instead of hard-coded in App and WorkingPanel.

Refactor PNG editing around registered tools and event-driven strokes, add preview and continuous draw/erase behavior, move camera-drag policy into mouse mode capabilities, and convert model-to-pointcloud generation to async runtime execution with busy-state UI feedback.